### PR TITLE
Normalize national ID document type and tweak mobile layout

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/sections/contacts/ContactsPanel.jsx
+++ b/sections/contacts/ContactsPanel.jsx
@@ -20,7 +20,7 @@ const MAX_ATTEMPTS = 5;
 
 // ID document types
 const ID_TYPES = [
-  { value: 'national_id',     label: 'ID Card' },
+  { value: 'national_id',     label: 'National ID' },
   { value: 'passport',        label: 'Passport' },
   { value: 'driver_license',  label: 'Driver License' },
   { value: 'residence_permit', label: 'Residence Permit' },
@@ -28,12 +28,30 @@ const ID_TYPES = [
 ];
 
 // --------- Helpers (sanitization & UI) ---------
-const ALLOWED_ID_TYPES = new Set(['national_id', 'passport', 'driver_license', 'residence_permit', 'other']);
+const ALLOWED_ID_TYPES = new Set([
+  'national_id',
+  'passport',
+  'driver_license',
+  'residence_permit',
+  'other',
+]);
 function normalizeIdType(v) {
   const s = (v ?? '').toString().trim().toLowerCase().replace(/[\s-]+/g, '_');
   if (ALLOWED_ID_TYPES.has(s)) return s;
-  if (s === 'id_card' || s === 'identity_card' || s === 'id') return 'national_id';
-  if (s === 'driving_license' || s === 'driving_licence' || s === 'licence' || s === 'license') return 'driver_license';
+  if (
+    s === 'id_card' ||
+    s === 'identity_card' ||
+    s === 'id' ||
+    s === 'idcard' ||
+    s === 'identitycard' ||
+    s === 'nationalid'
+  ) return 'national_id';
+  if (
+    s === 'driving_license' ||
+    s === 'driving_licence' ||
+    s === 'licence' ||
+    s === 'license'
+  ) return 'driver_license';
   if (s === 'residencepermit') return 'residence_permit';
   return '';
 }
@@ -758,8 +776,8 @@ const styles = {
   gridMobile: { gridTemplateColumns: '1fr' },
 
   // campi più distanziati
-  field: { display: 'flex', flexDirection: 'column', gap: 12 },
-  fieldWide: { gridColumn: '1 / -1', display: 'flex', flexDirection: 'column', gap: 12 },
+  field: { display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 12 },
+  fieldWide: { gridColumn: '1 / -1', display: 'flex', flexDirection: 'column', gap: 12, marginBottom: 12 },
 
   label: { fontSize: 13, fontWeight: 600 },
   input: {
@@ -855,11 +873,11 @@ const styles = {
     alignItems: 'stretch',
     gap: 10,
     paddingTop: 12,
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
     flexWrap: 'wrap'
   },
   buttonsWrap: { display: 'flex', alignItems: 'center', gap: 10, marginLeft: 'auto' },
-  buttonsWrapMobile: { display: 'flex', alignItems: 'center', gap: 8, marginLeft: 'auto' },
+  buttonsWrapMobile: { display: 'flex', alignItems: 'center', gap: 8 },
 
   saveBtn: { height: 38, padding: '0 16px', borderRadius: 8, fontWeight: 600, border: 'none' },
   saveBtnEnabled: { background: 'linear-gradient(90deg, #27E3DA, #F7B84E)', color: '#fff', cursor: 'pointer' },

--- a/sections/personal/PersonalPanel.jsx
+++ b/sections/personal/PersonalPanel.jsx
@@ -238,6 +238,10 @@ const saveBtnStyle =
     ? { ...styles.saveBtn, background: '#EEE', color: '#999', border: '1px solid #E0E0E0', cursor: 'not-allowed' }
     : { ...styles.saveBtn, background: 'linear-gradient(90deg, #27E3DA, #F7B84E)', color: '#fff', border: 'none', cursor: 'pointer' };
 
+  const saveBarStyle = isMobile
+    ? { ...styles.saveBar, justifyContent: 'flex-start' }
+    : styles.saveBar;
+
   return (
     <form
         onSubmit={(e) => { e.preventDefault(); onSave(); }}
@@ -412,7 +416,7 @@ const saveBtnStyle =
       </div>
 
       {/* Status + Save */}
-      <div style={styles.saveBar}>
+      <div style={saveBarStyle}>
           <button
             type="submit"
             disabled={isSaveDisabled}
@@ -464,7 +468,7 @@ function IconX({ small }) {
 
 const styles = {
   formGrid: { display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 16, alignItems: 'start' },
-  field: { display: 'flex', flexDirection: 'column', gap: 6 },
+  field: { display: 'flex', flexDirection: 'column', gap: 6, marginBottom: 12 },
   label: { fontSize: 12, opacity: 0.8 },
   input: { padding: '10px 12px', border: '1px solid #E0E0E0', borderRadius: 8, fontSize: 14, background: '#FFF' },
   select: { padding: '10px 12px', border: '1px solid #E0E0E0', borderRadius: 8, fontSize: 14, background: '#FFF', height: '40px' },


### PR DESCRIPTION
## Summary
- show **National ID** in contact form dropdown
- sanitize ID type to map various ID card variants to `national_id`
- ignore node_modules in version control
- align mobile action buttons to the left for easier thumb reach
- add spacing between form fields for clearer separation

## Testing
- `node - <<'NODE' ...`
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b2c2a22ed0832ba4f316a7eed30432