### PR TITLE
Include submitted_at in operator contacts verification query

### DIFF
--- a/pages/operator.js
+++ b/pages/operator.js
@@ -19,7 +19,7 @@ export default function Operator() {
         id, first_name, last_name,
         contacts_verification!left(
           id, phone_number, id_document_url, id_selfie_url,
-          review_status, rejected_reason, residence_address
+          review_status, rejected_reason, residence_address, submitted_at
         )
         `
       );


### PR DESCRIPTION
## Summary
- fetch contacts_verification.submitted_at alongside other fields in operator data load

## Testing
- `node -e "const { createClient } = require('@supabase/supabase-js'); const supabase = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY); console.log('url', process.env.NEXT_PUBLIC_SUPABASE_URL); console.log('key', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY);"` (fails: supabaseUrl is required)
- `npm run build` (fails: supabaseUrl is required)


------
https://chatgpt.com/codex/tasks/task_b_68b2dd53ff4c832b9f7a5fe8d182500f