### PR TITLE
Order contacts verification by submission date

### DIFF
--- a/pages/operator.js
+++ b/pages/operator.js
@@ -19,10 +19,11 @@ export default function Operator() {
         id, first_name, last_name,
         contacts_verification!left(
           id, phone_number, id_document_url, id_selfie_url,
-          review_status, rejected_reason, residence_address
+          review_status, rejected_reason, residence_address, submitted_at
         )
         `
-      );
+      )
+      .order('submitted_at', { foreignTable: 'contacts_verification', ascending: false });
     console.log(data);
     if (error) {
       console.error(error);
@@ -30,7 +31,8 @@ export default function Operator() {
     } else {
       const rows = await Promise.all(
         (data || []).map(async (a) => {
-          const cv = a.contacts_verification?.[0] || null;
+          const raw = a.contacts_verification;
+          const cv = raw?.[0] || null;
           if (cv) {
             const { data: docSigned } = cv.id_document_url
               ? await supabase.storage


### PR DESCRIPTION
## Summary
- sort nested `contacts_verification` by `submitted_at` to retrieve latest record first
- safely access the first entry with optional chaining

## Testing
- `npm test` *(fails: Missing script "test")*

## Notes
- Consider adding a unique constraint on `contacts_verification.athlete_id` in Supabase to prevent duplicates

------
https://chatgpt.com/codex/tasks/task_b_68b2de0731dc832ba6115fae5775adad