### PR TITLE
Normalize review_status values for operator and contacts

### DIFF
--- a/pages/operator.js
+++ b/pages/operator.js
@@ -32,6 +32,7 @@ export default function Operator() {
         (data || []).map(async (a) => {
           const cv = a.contacts_verification?.[0] || null;
           if (cv) {
+            cv.review_status = cv.review_status?.trim().toLowerCase();
             const { data: docSigned } = cv.id_document_url
               ? await supabase.storage
                   .from('documents')

--- a/sections/contacts/ContactsPanel.jsx
+++ b/sections/contacts/ContactsPanel.jsx
@@ -138,6 +138,8 @@ export default function ContactsPanel({ athlete, onSaved, isMobile }) {
           .eq('athlete_id', athlete.id)
           .single();
 
+        if (cvRow) cvRow.review_status = cvRow.review_status?.trim().toLowerCase();
+
         // phone: prefer athlete.phone, fallback cvRow.phone_number
         const rawPhone = athlete?.phone || cvRow?.phone_number || '';
         const normalizedPhone = normalizePhone(rawPhone);


### PR DESCRIPTION
## Summary
- Trim and lowercase review_status values when loading operator data
- Normalize review_status in contacts panel prefill

## Testing
- `npm run build` *(fails: supabaseUrl is required)*
- `node -e "let cv={review_status:'  Submitted  '}; cv.review_status=cv.review_status?.trim().toLowerCase(); console.log(cv.review_status);"`


------
https://chatgpt.com/codex/tasks/task_b_68b2df27b3d0832ba5b1aa3d66c730fd