### PR TITLE
Move seeking team flag to sports experiences

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -80,8 +80,7 @@ export default function Dashboard() {
                   profile_published,
                   completion_percentage,
                   current_step,
-                  needs_parental_authorization,
-                  seeking_team
+                  needs_parental_authorization
                 `)
 
           .eq('id', u.id)
@@ -109,12 +108,22 @@ export default function Dashboard() {
       .eq('athlete_id', u.id)
       .single();
     
+    const { data: expRows } = await supabase
+      .from('sports_experiences')
+      .select('seeking_team')
+      .eq('athlete_id', u.id)
+      .order('id', { ascending: false })
+      .limit(1);
+
+    const latestSeeking = Array.isArray(expRows) && expRows.length > 0 ? !!expRows[0].seeking_team : false;
+
     const merged = {
       ...data,
       residence_city: cv?.residence_city || '',
-      residence_country: cv?.residence_country || ''
+      residence_country: cv?.residence_country || '',
+      seeking_team: latestSeeking,
     };
-    
+
     if (mounted) setAthlete(merged);
       } catch (e) {
         console.error(e);


### PR DESCRIPTION
## Summary
- hydrate step 3 from latest sports_experiences including seeking_team and ignore athlete.seeking_team
- store seeking_team in sports_experiences on save and update athlete only with step progress
- fetch seeking_team for dashboard from latest sports_experiences instead of athlete table

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68b342053bf0832bb745da55f73411de