### PR TITLE
Ensure sport column select fills full width

### DIFF
--- a/sections/sports/SportInfoPanel.jsx
+++ b/sections/sports/SportInfoPanel.jsx
@@ -47,6 +47,7 @@ const buildDateRange = (start, end) => (start && end ? `[${start},${end}]` : nul
 
 // ---- react-select styles (coerenti) ----
 const makeSelectStyles = (hasError) => ({
+  container: (base) => ({ ...base, width: '100%' }),
   control: (base, state) => ({
     ...base,
     minHeight: 42,
@@ -1014,7 +1015,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         <div style={styles.error}>{editErrors.season_start || editErrors.season_end}</div>
                       )}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null), minWidth: 150 }}>
                       {isEditing ? (
                         <Select
                           options={sports}


### PR DESCRIPTION
## Summary
- ensure react-select containers span full width
- set a minimum width for sport column cells in career table

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Error: supabaseUrl is required.)

------
https://chatgpt.com/codex/tasks/task_b_68b4964680c0832b8df87cf04fb9c4cc