### PR TITLE
Center current season checkbox

### DIFF
--- a/sections/sports/SportInfoPanel.jsx
+++ b/sections/sports/SportInfoPanel.jsx
@@ -1070,16 +1070,14 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         />
                       ) : (r.league || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null), textAlign: 'center' }}>
                       {isEditing ? (
-                        <label style={{ display: 'inline-flex', alignItems: 'center', gap: 6 }}>
-                          <input
-                            type="checkbox"
-                            checked={!!edit.is_current}
-                            onChange={(e) => setEdit((p) => ({ ...p, is_current: e.target.checked }))}
-                          />
-                          <span>Current</span>
-                        </label>
+                        <input
+                          type="checkbox"
+                          aria-label="Current season"
+                          checked={!!edit.is_current}
+                          onChange={(e) => setEdit((p) => ({ ...p, is_current: e.target.checked }))}
+                        />
                       ) : (
                         r.is_current ? 'Yes' : '—'
                       )}


### PR DESCRIPTION
## Summary
- Center checkbox for current season and replace label with input only
- Remove redundant text span to save horizontal space

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_b_68b497570220832bb8b4c416a9ea9e44