### PR TITLE
Improve mobile table layout

### DIFF
--- a/sections/sports/SportInfoPanel.jsx
+++ b/sections/sports/SportInfoPanel.jsx
@@ -977,14 +977,14 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
           <table style={styles.table}>
             <thead>
               <tr>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Season</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Sport</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Team</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Role</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Category</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>League</th>
-                <th style={{ ...styles.th, ...(isMobile ? styles.thMobile : null) }}>Current</th>
-                <th style={{ ...styles.thRight, ...(isMobile ? styles.thMobile : null) }}>Actions</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Season</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Sport</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Team</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Role</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Category</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>League</th>
+                <th style={{ ...styles.th, ...(isMobile ? styles.mobileCell : null) }}>Current</th>
+                <th style={{ ...styles.thRight, ...(isMobile ? styles.mobileCell : null) }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -992,7 +992,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                 const isEditing = editId === r.id;
                 return (
                   <tr key={r.id}>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null) }}>
                       {isEditing ? (
                         <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8 }}>
                       <input
@@ -1015,7 +1015,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         <div style={styles.error}>{editErrors.season_start || editErrors.season_end}</div>
                       )}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null), minWidth: 150 }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null), minWidth: 150 }}>
                       {isEditing ? (
                         <Select
                           options={sports}
@@ -1025,7 +1025,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         />
                       ) : (r.sport || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null) }}>
                       {isEditing ? (
                         <>
                           <input
@@ -1037,7 +1037,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         </>
                       ) : (r.team_name || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null) }}>
                       {isEditing ? (
                         <>
                           <input
@@ -1049,7 +1049,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         </>
                       ) : (r.role || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null) }}>
                       {isEditing ? (
                         <>
                           <input
@@ -1061,7 +1061,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         </>
                       ) : (r.category || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null) }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null) }}>
                       {isEditing ? (
                         <input
                           value={edit.league}
@@ -1070,7 +1070,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         />
                       ) : (r.league || '-')}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null), textAlign: 'center' }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null), textAlign: 'center' }}>
                       {isEditing ? (
                         <input
                           type="checkbox"
@@ -1082,7 +1082,7 @@ function CareerWidget({ athleteId, defaultSport, isMobile }) {
                         r.is_current ? 'Yes' : '—'
                       )}
                     </td>
-                    <td style={{ ...styles.td, ...(isMobile ? styles.tdMobile : null), textAlign: 'right', whiteSpace: 'nowrap' }}>
+                    <td style={{ ...styles.td, ...(isMobile ? styles.mobileCell : null), textAlign: 'right', whiteSpace: 'nowrap' }}>
                       {!isEditing ? (
                         <>
                           <button type="button" style={styles.linkBtn} onClick={() => onEdit(r)}>Edit</button>
@@ -1140,6 +1140,7 @@ const styles = {
     borderRadius: 10,
     fontSize: 14,
     background: '#FFF',
+    width: '100%',
   },
   careerInput: {
     height: 38,
@@ -1148,6 +1149,7 @@ const styles = {
     borderRadius: 10,
     fontSize: 14,
     background: '#FFF',
+    width: '100%',
   },
   error: { fontSize: 12, color: '#b00' },
 
@@ -1222,14 +1224,13 @@ const styles = {
     whiteSpace: 'nowrap',
   },
   thRight: { textAlign: 'right', fontSize: 12, fontWeight: 700, padding: '10px 12px', borderBottom: '1px solid #EEE' },
-  thMobile: { padding: '12px 16px', minWidth: 100 },
+  mobileCell: { padding: '12px 16px', minWidth: 150 },
   td: {
     fontSize: 14,
     padding: '10px 12px',
     borderBottom: '1px solid #F5F5F5',
     verticalAlign: 'top',
   },
-  tdMobile: { padding: '12px 16px', minWidth: 100 },
 
   careerForm: {
     display: 'grid',


### PR DESCRIPTION
## Summary
- widen mobile table columns via shared mobileCell style
- make edit inputs span full cell width for better usability

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68b49905e394832b918e794b199df4eb