### PR TITLE
Widen mobile column widths in SportInfoPanel

### DIFF
--- a/sections/sports/SportInfoPanel.jsx
+++ b/sections/sports/SportInfoPanel.jsx
@@ -1223,14 +1223,14 @@ const styles = {
     whiteSpace: 'nowrap',
   },
   thRight: { textAlign: 'right', fontSize: 12, fontWeight: 700, padding: '10px 12px', borderBottom: '1px solid #EEE' },
-  thMobile: { padding: '12px 16px', minWidth: 100 },
+  thMobile: { padding: '12px 20px', minWidth: 180 },
   td: {
     fontSize: 14,
     padding: '10px 12px',
     borderBottom: '1px solid #F5F5F5',
     verticalAlign: 'top',
   },
-  tdMobile: { padding: '12px 16px', minWidth: 100 },
+  tdMobile: { padding: '12px 20px', minWidth: 180 },
 
   careerForm: {
     display: 'grid',


### PR DESCRIPTION
## Summary
- widen mobile table columns by increasing minWidth and padding

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_b_68b49cf21e30832b9dbdac52c42d7b9f