### PR TITLE
Remove circular styling from PhysicalPanel help button

### DIFF
--- a/sections/physical/PhysicalPanel.jsx
+++ b/sections/physical/PhysicalPanel.jsx
@@ -822,17 +822,13 @@ const styles = {
 
   // Help (?)
   helpBtn: {
-    width: 18,
-    height: 18,
     display: 'flex',
     alignItems: 'center',
     justifyContent: 'center',
-    borderRadius: '50%',
-    border: '1px solid #E0E0E0',
-    background: '#FFF',
+    background: 'transparent',
     cursor: 'pointer',
-    fontSize: 12,
-    fontWeight: 700,
+    fontSize: 13,
+    fontWeight: 600,
     padding: 0,
     color: '#333',
     flexShrink: 0,


### PR DESCRIPTION
## Summary
- restyle help button in PhysicalPanel to use transparent background and match label typography

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68b5f10b10a8832b9dd2bc196bd533af