### PR TITLE
Import MediaPanel and remove duplicate section

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -7,6 +7,7 @@ import PersonalPanel from '../sections/personal/PersonalPanel';
 import ContactsPanel from '../sections/contacts/ContactsPanel';
 import SportInfoPanel from '../sections/sports/SportInfoPanel';
 import PhysicalPanel from '../sections/physical/PhysicalPanel';
+import MediaPanel from '../sections/media/MediaPanel';
 import AwardsWidget from '../sections/awards/AwardsWidget';
 
 const ATHLETE_TABLE = 'athlete';

--- a/utils/dashboardSections.js
+++ b/utils/dashboardSections.js
@@ -10,7 +10,6 @@ export const SECTIONS = [
   { id: 'media',     title: 'Media' },
   { id: 'social',    title: 'Social' },
   { id: 'privacy',   title: 'Privacy & consent' },
-  { id: 'media',    title: 'Media' },
 ];
 
 /** @type {'personal'|'contacts'|'sports'|'physical'|'media'|'social'|'awards'|'privacy'} */


### PR DESCRIPTION
## Summary
- add MediaPanel import to dashboard page
- remove duplicate 'media' entry from dashboard sections

## Testing
- `npm test` *(fails: Missing script "test")*
- `NEXT_PUBLIC_SUPABASE_URL=https://example.com NEXT_PUBLIC_SUPABASE_ANON_KEY=anonkey npm run build`

------
https://chatgpt.com/codex/tasks/task_b_68ba9401bac8832ba687d14519f6179a