### PR TITLE
Expand featured media preview width

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -125,7 +125,7 @@ const styles = {
   },
   featuredPreview: {
     width: '100%',
-    maxWidth: 200,
+    maxWidth: 300,
     aspectRatio: '4 / 3',
     background: '#F7F7F7',
     border: '1px solid #EEE',


### PR DESCRIPTION
## Summary
- enlarge featured preview placeholders to max width 300px for better image display
- maintain three-slot grid layout for featured media section

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68bb43e465f4832b971ca56767b75686