### PR TITLE
Expand media preview width

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -137,7 +137,7 @@ const styles = {
   // Player video
   mediaPreview: {
     width: '100%',
-    maxWidth: 320,
+    maxWidth: 420,
     aspectRatio: '16 / 9',
     background: '#000',
     border: '1px solid #EEE',
@@ -1757,7 +1757,7 @@ function HLPlayer({ item, getSigned, usePoster }) {
     return (
       <div style={{ marginTop: 6 }}>
         {!showEmbed ? (
-          <div style={{ position: 'relative', width: '100%', maxWidth: 320, margin: '0 auto' }}>
+          <div style={{ position: 'relative', width: '100%', maxWidth: 420, margin: '0 auto' }}>
             {poster ? <img alt="Poster" src={poster} style={styles.mediaPreview} /> : <div style={styles.mediaPreview} />}
             <button
               type="button"


### PR DESCRIPTION
## Summary
- expand `mediaPreview` maxWidth from 320 to 420px
- adjust highlight container to match new preview width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68bb48b8428c832bb806c338ebb7d1e9