### PR TITLE
feat: open gallery items in new tab

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -1760,6 +1760,12 @@ function GalleryAccordionItem({ item, isOpen, onToggle, editGalleryField, onSave
     })();
   }, [item?.storage_path]);
 
+  const handleOpen = async () => {
+    const url = item.external_url ||
+                (item.storage_path ? await getSigned(item.storage_path) : '#');
+    window.open(url, '_blank', 'noopener,noreferrer');
+  };
+
   return (
     <div style={styles.galleryCard}>
       <button
@@ -1824,7 +1830,7 @@ function GalleryAccordionItem({ item, isOpen, onToggle, editGalleryField, onSave
             <button
               type="button"
               style={styles.smallBtn}
-              onClick={() => window.open(item.external_url || '#', '_blank', 'noopener,noreferrer')}
+              onClick={handleOpen}
             >
               Open
             </button>


### PR DESCRIPTION
## Summary
- enable Gallery accordion Open button to resolve signed URLs before opening

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: supabaseUrl is required during build)


------
https://chatgpt.com/codex/tasks/task_b_68bb5492ddcc832bb055be2cdb93d469