### PR TITLE
Remove profile URL from social accordion titles

### DIFF
--- a/sections/social/SocialPanel.jsx
+++ b/sections/social/SocialPanel.jsx
@@ -559,7 +559,7 @@ function SocialAccordionItem({ row, onField, onTogglePublic, onTogglePrimary, on
   const summaryId = `social-summary-${row.id}`;
   const regionId  = `social-region-${row.id}`;
 
-  const title = [row.platform || '—', row.handle ? `• ${row.handle}` : '', row.profile_url ? `• ${row.profile_url}` : '']
+  const title = [row.platform || '—', row.handle ? `• ${row.handle}` : '']
     .filter(Boolean).join(' ');
 
   return (


### PR DESCRIPTION
## Summary
- omit profile URL from social accordion item titles, leaving platform and handle only

## Testing
- `node -e 'const row={platform:"LinkedIn", handle:"user123", profile_url:"https://example.com/user123"}; const title=[row.platform||"—", row.handle?`• ${row.handle}`:""] .filter(Boolean).join(" "); console.log(title);'`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_b_68bc9406cad8832ba9f0ca7fbbd17621