### PR TITLE
Refine SocialPanel checkbox layout

### DIFF
--- a/sections/social/SocialPanel.jsx
+++ b/sections/social/SocialPanel.jsx
@@ -395,30 +395,32 @@ export default function SocialPanel({ athlete, onSaved, isMobile }) {
           />
         </div>
         <div className="row" style={{ ...styles.fieldRow, gap: 16, marginBottom: 12 }}>
-        <div style={styles.checkboxRow}>
-          <input
-            id="add-public"
-            type="checkbox"
-            checked={!!add.is_public}
-            onChange={() => setAdd(s => ({ ...s, is_public: !s.is_public }))}
-            aria-label="Public"
-          />
-          <label htmlFor="add-public" style={{ marginLeft: 4 }}>Public</label>
-        </div>
-        <div style={styles.checkboxRow}>
-          <input
-            id="add-primary"
-            type="checkbox"
-            checked={!!add.is_primary}
-            onChange={() => setAdd(s => ({ ...s, is_primary: !s.is_primary }))}
-            aria-label="Primary"
-          />
-          <label htmlFor="add-primary" style={{ marginLeft: 4 }}>Primary</label>
-        </div>
+          <div style={{ display: 'flex', gap: 16 }}>
+            <div style={styles.checkboxRow}>
+              <input
+                id="add-public"
+                type="checkbox"
+                checked={!!add.is_public}
+                onChange={() => setAdd(s => ({ ...s, is_public: !s.is_public }))}
+                aria-label="Public"
+              />
+              <label htmlFor="add-public" style={{ marginLeft: 4 }}>Public</label>
+            </div>
+            <div style={styles.checkboxRow}>
+              <input
+                id="add-primary"
+                type="checkbox"
+                checked={!!add.is_primary}
+                onChange={() => setAdd(s => ({ ...s, is_primary: !s.is_primary }))}
+                aria-label="Primary"
+              />
+              <label htmlFor="add-primary" style={{ marginLeft: 4 }}>Primary</label>
+            </div>
+          </div>
           <button
             type="button"
             onClick={addRow}
-            style={{ ...styles.smallBtnPrimary, marginLeft: 'auto' }}
+            style={{ ...styles.smallBtnPrimary, flexBasis: '100%' }}
           >
             + Add
           </button>


### PR DESCRIPTION
## Summary
- Group public and primary checkboxes in a flex container for tighter spacing
- Move "+ Add" button to its own line using `flexBasis: '100%'`

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Module not found: Can't resolve 'react-icons/fi')

------
https://chatgpt.com/codex/tasks/task_b_68bc940fcaec832bacade6ffb932e739