### PR TITLE
Refactor checkbox layout in SocialAccordionItem

### DIFF
--- a/sections/social/SocialPanel.jsx
+++ b/sections/social/SocialPanel.jsx
@@ -637,33 +637,25 @@ function SocialAccordionItem({ row, onField, onTogglePublic, onTogglePrimary, on
             {rowError && !String(row.profile_url || '').trim() && <div style={styles.error}>URL is required.</div>}
           </div>
 
-          <div style={{ display: 'flex', gap: 16, flexWrap: 'wrap' }}>
-            <label
-              style={{ display: 'flex', alignItems: 'center' }}
-              htmlFor={`pub-m-${row.id}`}
-            >
-              <input
-                id={`pub-m-${row.id}`}
-                type="checkbox"
-                checked={!!row.is_public}
-                onChange={() => onTogglePublic(row.id)}
-                aria-label="Public"
-              />
-              <span style={{ marginLeft: 4 }}>Public</span>
-            </label>
-            <label
-              style={{ display: 'flex', alignItems: 'center' }}
-              htmlFor={`pri-m-${row.id}`}
-            >
-              <input
-                id={`pri-m-${row.id}`}
-                type="checkbox"
-                checked={!!row.is_primary}
-                onChange={() => onTogglePrimary(row.id)}
-                aria-label="Primary"
-              />
-              <span style={{ marginLeft: 4 }}>Primary</span>
-            </label>
+          <div style={styles.field}>
+            <label htmlFor={`pub-m-${row.id}`} style={styles.label}>Public</label>
+            <input
+              id={`pub-m-${row.id}`}
+              type="checkbox"
+              checked={!!row.is_public}
+              onChange={() => onTogglePublic(row.id)}
+              aria-label="Public"
+            />
+          </div>
+          <div style={styles.field}>
+            <label htmlFor={`pri-m-${row.id}`} style={styles.label}>Primary</label>
+            <input
+              id={`pri-m-${row.id}`}
+              type="checkbox"
+              checked={!!row.is_primary}
+              onChange={() => onTogglePrimary(row.id)}
+              aria-label="Primary"
+            />
           </div>
 
           <div style={styles.actions}>


### PR DESCRIPTION
## Summary
- Replace horizontal checkbox container in SocialAccordionItem with two full-width field rows
- Preserve existing ids and handlers while removing flex layout

## Testing
- `npm test` *(fails: Missing script "test"; no tests defined)*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68bc9e9b315c832b9bf23357698800e3