### PR TITLE
refactor: align mobile social checkboxes

### DIFF
--- a/sections/social/SocialPanel.jsx
+++ b/sections/social/SocialPanel.jsx
@@ -637,25 +637,27 @@ function SocialAccordionItem({ row, onField, onTogglePublic, onTogglePrimary, on
             {rowError && !String(row.profile_url || '').trim() && <div style={styles.error}>URL is required.</div>}
           </div>
 
-          <div style={styles.field}>
-            <label htmlFor={`pub-m-${row.id}`} style={styles.label}>Public</label>
-            <input
-              id={`pub-m-${row.id}`}
-              type="checkbox"
-              checked={!!row.is_public}
-              onChange={() => onTogglePublic(row.id)}
-              aria-label="Public"
-            />
-          </div>
-          <div style={styles.field}>
-            <label htmlFor={`pri-m-${row.id}`} style={styles.label}>Primary</label>
-            <input
-              id={`pri-m-${row.id}`}
-              type="checkbox"
-              checked={!!row.is_primary}
-              onChange={() => onTogglePrimary(row.id)}
-              aria-label="Primary"
-            />
+          <div style={{ ...styles.fieldRow, gap: 16, marginBottom: 12 }}>
+            <div style={styles.checkboxRow}>
+              <input
+                id={`pub-m-${row.id}`}
+                type="checkbox"
+                checked={!!row.is_public}
+                onChange={() => onTogglePublic(row.id)}
+                aria-label="Public"
+              />
+              <label htmlFor={`pub-m-${row.id}`} style={styles.label}>Public</label>
+            </div>
+            <div style={styles.checkboxRow}>
+              <input
+                id={`pri-m-${row.id}`}
+                type="checkbox"
+                checked={!!row.is_primary}
+                onChange={() => onTogglePrimary(row.id)}
+                aria-label="Primary"
+              />
+              <label htmlFor={`pri-m-${row.id}`} style={styles.label}>Primary</label>
+            </div>
           </div>
 
           <div style={styles.actions}>


### PR DESCRIPTION
## Summary
- group Public and Primary checkboxes in SocialAccordionItem into a flex row container to align inputs and labels horizontally
- keep existing IDs and callbacks while preserving desktop implementation

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68bca14f0c64832b9ca2004ac15a4c9a