### PR TITLE
Replace lucide icons and add profile preview link

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -196,7 +196,7 @@ export default function Dashboard() {
   // --- Stili dinamici derivati (mobile vs desktop)
   const headerStyle = { ...styles.header, ...(isMobile ? styles.headerMobile : null) };
   const headerLeftStyle = { ...styles.headerLeft, ...(isMobile ? styles.headerLeftMobile : null) };
-  const authWrapStyle = { ...(isMobile ? styles.authWrapMobileSlot : {}) };
+  const headerRightStyle = { display: 'flex', alignItems: 'center', gap: 12, ...(isMobile ? styles.authWrapMobileSlot : {}) };
 
   const subHeaderStyle = { ...styles.subHeader, ...(isMobile ? styles.subHeaderMobile : null) };
   const progressBarStyle = { ...styles.progressBar, ...(isMobile ? { width: '100%' } : null) };
@@ -214,7 +214,16 @@ export default function Dashboard() {
           </div>
         </div>
 
-        <div style={authWrapStyle}>
+        <div style={headerRightStyle}>
+          <a
+            href="/profile/preview"
+            style={styles.link}
+            target="_blank"
+            rel="noopener noreferrer"
+          >
+            Preview
+          </a>
+          {!isMobile && <span style={{ margin: '0 8px' }}>|</span>}
           <AuthControl
             email={user?.email}
             avatarUrl={athlete?.profile_picture_url}

--- a/pages/profile/preview.jsx
+++ b/pages/profile/preview.jsx
@@ -13,9 +13,22 @@
 import { useEffect, useMemo, useRef, useState } from 'react';
 import { useRouter } from 'next/router';
 import {
-  Play, Mail, Phone, Globe, MapPin, BadgeCheck, ShieldCheck, Link as LinkIcon,
-  ChevronRight, ChevronDown, ExternalLink, Verified, Image as ImageIcon, Video, Award
-} from 'lucide-react';
+  FiPlay as Play,
+  FiMail as Mail,
+  FiPhone as Phone,
+  FiGlobe as Globe,
+  FiMapPin as MapPin,
+  FiCheckCircle as BadgeCheck,
+  FiShield as ShieldCheck,
+  FiLink as LinkIcon,
+  FiChevronRight as ChevronRight,
+  FiChevronDown as ChevronDown,
+  FiExternalLink as ExternalLink,
+  FiCheck as Verified,
+  FiImage as ImageIcon,
+  FiVideo as Video,
+  FiAward as Award,
+} from 'react-icons/fi';
 import { supabase } from '../../utils/supabaseClient';
 
 // ---- Costanti stile (coerenti con il progetto)


### PR DESCRIPTION
## Summary
- Use `react-icons/fi` instead of missing `lucide-react` icons in profile preview page
- Add "Preview" link in dashboard header pointing to `/profile/preview`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: supabaseUrl is required)*

------
https://chatgpt.com/codex/tasks/task_b_68bcbe636c80832b8510017b6173edf0