### PR TITLE
Fix AsyncImage useEffect dependency for AthleteShowcaseCard

### DIFF
--- a/components/AthleteShowcaseCard.jsx
+++ b/components/AthleteShowcaseCard.jsx
@@ -1040,13 +1040,15 @@ export default function AthleteShowcaseCard({ athleteId }) {
 // ---- Support: immagine async con signed URL + onClick (lightbox) ----
 function AsyncImage({ alt, path, getSigned, style, onClick }) {
   const [src, setSrc] = useState('');
-  useEffect(()=> { (async()=> {
-    if (!path) return;
-    const url = isHttpUrl(path) ? path : await getSigned(path);
-    setSrc(url || '');
-  })(); }, [path]);
+  useEffect(() => {
+    (async () => {
+      if (!path) return;
+      const url = isHttpUrl(path) ? path : await getSigned(path);
+      setSrc(url || '');
+    })();
+  }, [path, getSigned]);
   return (
-    <img alt={alt} src={src} loading="lazy" decoding="async" style={{ ...style, cursor:'zoom-in' }} onClick={()=>onClick?.(src)} />
+    <img alt={alt} src={src} loading="lazy" decoding="async" style={{ ...style, cursor: 'zoom-in' }} onClick={() => onClick?.(src)} />
   );
 }
 


### PR DESCRIPTION
## Summary
- include `getSigned` in `AsyncImage` effect dependencies
- ensure signed URL getter remains memoized via `useSignedUrlCache`

## Testing
- `npm test` *(fails: Missing script "lint")*
- `npm run build` *(fails: Module not found: Can't resolve 'lucide-react')*

------
https://chatgpt.com/codex/tasks/task_b_68bcd07c7ce4832bb3ab252767b377c0