### PR TITLE
refactor: centralize signed URL cache hook

### DIFF
--- a/components/AthleteShowcaseCard.jsx
+++ b/components/AthleteShowcaseCard.jsx
@@ -9,8 +9,9 @@
 // - Schemi tabelle (campi chiave): media_item/media_game_meta/athlete/contacts_verification/physical_data/athlete_career 
 // - Supabase client centralizzato  :contentReference[oaicite:13]{index=13}
 'use client';
-import React, { useEffect, useMemo, useRef, useState, useCallback } from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import { supabase as sb } from '../utils/supabaseClient';
+import { useSignedUrlCache } from '../utils/useSignedUrlCache';
 import {
   Play, Film, Image as ImageIcon, ChevronRight, ChevronDown,
   Calendar, Award as AwardIcon, Medal, Phone, Mail, Globe, MapPin, User, Flag, ExternalLink,
@@ -118,22 +119,6 @@ const flagFromCountry = (name='') => {
   return chars.join('');
 };
 
-// Cache Signed URL 60s
-function useSignedUrlCache(bucket) {
-  const cacheRef = useRef(new Map());
-  return useCallback(async (storagePath) => {
-    if (!storagePath) return '';
-    const k = `${bucket}:${storagePath}`;
-    const hit = cacheRef.current.get(k);
-    const now = Date.now();
-    if (hit && hit.exp > now + 2000) return hit.url;
-    const { data, error } = await supabase.storage.from(bucket).createSignedUrl(storagePath, 60);
-    if (error) return '';
-    const url = data?.signedUrl || '';
-    cacheRef.current.set(k, { url, exp: now + 55_000 });
-    return url;
-  }, [bucket]);
-}
 
 // ---------- Stili (inline, coerenti token progetto) ----------
 const styles = {

--- a/utils/useSignedUrlCache.js
+++ b/utils/useSignedUrlCache.js
@@ -1,0 +1,25 @@
+"use client";
+
+import { useRef, useCallback } from 'react';
+import { supabase } from './supabaseClient';
+
+export function useSignedUrlCache(bucket) {
+  const cacheRef = useRef(new Map());
+  return useCallback(
+    async (storagePath) => {
+      if (!storagePath) return '';
+      const key = `${bucket}:${storagePath}`;
+      const hit = cacheRef.current.get(key);
+      const now = Date.now();
+      if (hit && hit.exp > now + 2000) return hit.url;
+      const { data, error } = await supabase.storage
+        .from(bucket)
+        .createSignedUrl(storagePath, 60);
+      if (error) return '';
+      const url = data?.signedUrl || '';
+      cacheRef.current.set(key, { url, exp: now + 55_000 });
+      return url;
+    },
+    [bucket]
+  );
+}


### PR DESCRIPTION
## Summary
- import shared signed URL cache hook into AthleteShowcaseCard
- add reusable useSignedUrlCache utility

## Testing
- `npm test` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68bcd8249730832b982770e5bab34853