### PR TITLE
fix: avoid Supabase queries without athlete id

### DIFF
--- a/components/AthleteShowcaseCard.jsx
+++ b/components/AthleteShowcaseCard.jsx
@@ -260,6 +260,7 @@ export default function AthleteShowcaseCard({ athleteId }) {
 
   // Load
   useEffect(() => {
+    if (!athleteId) return; // avoid queries without athleteId
     let mounted = true;
     (async () => {
       try {
@@ -469,6 +470,7 @@ export default function AthleteShowcaseCard({ athleteId }) {
   };
 
   // ---------- Render ----------
+  if (!athleteId) return null; // nothing to show until athleteId available
   if (loading) {
     return (
       <div style={styles.container}>


### PR DESCRIPTION
## Summary
- guard data loading in AthleteShowcaseCard until an athlete id is present
- return nothing from AthleteShowcaseCard when athlete id is missing

## Testing
- `npm test` *(fails: Missing script "lint")*
- `npm install --no-save react-test-renderer` *(fails: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_b_68bcd823bfbc832b8c79818792ac0b1b