### PR TITLE
Remove showcase section from dashboard

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -10,7 +10,6 @@ import PhysicalPanel from '../sections/physical/PhysicalPanel';
 import MediaPanel from '../sections/media/MediaPanel';
 import SocialPanel from '../sections/social/SocialPanel';
 import AwardsWidget from '../sections/awards/AwardsWidget';
-import AthleteShowcaseCard from '../components/AthleteShowcaseCard';
 
 const ATHLETE_TABLE = 'athlete';
 
@@ -216,13 +215,6 @@ export default function Dashboard() {
         </div>
 
         <div style={headerRightStyle}>
-          <button
-            onClick={() => setSection('showcase')}
-            style={{ ...styles.link, background: 'none', border: 'none', padding: 0, cursor: 'pointer' }}
-          >
-            Preview
-          </button>
-          {!isMobile && <span style={{ margin: '0 8px' }}>|</span>}
           <AuthControl
             email={user?.email}
             avatarUrl={athlete?.profile_picture_url}
@@ -377,10 +369,7 @@ export default function Dashboard() {
                 {current === 'awards' && (
                   <AwardsWidget athleteId={athlete?.id} isMobile={isMobile} />
                 )}
-                {current === 'showcase' && (
-                  <AthleteShowcaseCard athleteId={athlete?.id} />
-                )}
-                {current !== 'personal' && current !== 'contacts' && current !== 'sports' && current !== 'media' && current !== 'social' && current !== 'physical' && current !== 'awards' && current !== 'showcase' && (
+                {current !== 'personal' && current !== 'contacts' && current !== 'sports' && current !== 'media' && current !== 'social' && current !== 'physical' && current !== 'awards' && (
                   <p style={styles.placeholder}>TODO — “{sectionObj?.title}”</p>
                 )}
 

--- a/utils/dashboardSections.js
+++ b/utils/dashboardSections.js
@@ -9,11 +9,10 @@ export const SECTIONS = [
   { id: 'awards',    title: 'Awards' },
   { id: 'media',     title: 'Media' },
   { id: 'social',    title: 'Social' },
-  { id: 'showcase',  title: 'Profile preview' },
   { id: 'privacy',   title: 'Privacy & consent' },
 ];
 
-/** @type {'personal'|'contacts'|'sports'|'physical'|'media'|'social'|'awards'|'privacy'|'showcase'} */
+/** @type {'personal'|'contacts'|'sports'|'physical'|'media'|'social'|'awards'|'privacy'} */
 export const DEFAULT_SECTION = 'personal';
 
 /** Validate a section id coming from the URL (e.g. ?section=...). */


### PR DESCRIPTION
## Summary
- drop "Profile preview" from dashboard sections and typing
- remove showcase navigation and rendering from the dashboard page

## Testing
- `npm test` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68bd2a3a9ee8832ba40371aeb6133fbd