### PR TITLE
Add Preview link to dashboard auth menu

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -387,6 +387,8 @@ function AuthControl({ email, avatarUrl, onLogout, compact }) {
   return (
     <div style={{ ...styles.authWrap, ...(compact ? styles.authWrapMobile : null) }}>
       <a href="/index" style={styles.link}>Home</a>
+      <span style={{ margin: '0 8px' }}>|</span>
+      <a href="/profile/preview" style={styles.link}>Preview</a>
       {!compact && <span style={{ margin: '0 8px' }}>|</span>}
       <div style={styles.authBox}>
         {avatarUrl


### PR DESCRIPTION
## Summary
- Add Preview link to dashboard AuthControl header
- Show separators around Home and Preview links, mirroring desktop behavior

## Testing
- `npm test` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68bd35648658832b86cb4916d1443476