### PR TITLE
Pass athleteId to AuthControl for preview link

### DIFF
--- a/pages/dashboard.js
+++ b/pages/dashboard.js
@@ -220,6 +220,7 @@ export default function Dashboard() {
             avatarUrl={athlete?.profile_picture_url}
             onLogout={handleLogout}
             compact={isMobile}
+            athleteId={athlete?.id}
           />
         </div>
       </header>
@@ -383,12 +384,15 @@ export default function Dashboard() {
 }
 
 /** Login/logout in alto a destra */
-function AuthControl({ email, avatarUrl, onLogout, compact }) {
+function AuthControl({ email, avatarUrl, onLogout, compact, athleteId }) {
   return (
     <div style={{ ...styles.authWrap, ...(compact ? styles.authWrapMobile : null) }}>
       <a href="/index" style={styles.link}>Home</a>
       <span style={{ margin: '0 8px' }}>|</span>
-      <a href="/profile/preview" style={styles.link}>Preview</a>
+      {athleteId
+        ? <a href={`/profile/preview?id=${athleteId}`} style={styles.link}>Preview</a>
+        : <a style={{ ...styles.link, pointerEvents: 'none', opacity: 0.5 }}>Preview</a>
+      }
       {!compact && <span style={{ margin: '0 8px' }}>|</span>}
       <div style={styles.authBox}>
         {avatarUrl


### PR DESCRIPTION
## Summary
- Pass athlete ID to AuthControl component
- Update AuthControl to accept athleteId and link to `/profile/preview?id=...`

## Testing
- `npm test` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68bd5643a528832b907080a9c09b4175