### PR TITLE
chore: add system font stack to profile preview

### DIFF
--- a/pages/profile/preview.js
+++ b/pages/profile/preview.js
@@ -65,12 +65,14 @@ export default function ProfilePreviewPage() {
   return (
     <>
       <Head><title>Profile preview</title></Head>
-      {!athleteId ? (
-        <div style={{ maxWidth: 960, margin: '40px auto', padding: '0 16px' }}>
-          <h1 style={{ fontSize: 22, fontWeight: 800, marginBottom: 8 }}>Missing athlete id</h1>
-          <p>Apri come <code>/profile/preview?id=&lt;athleteId&gt;</code>.</p>
-        </div>
-      ) : <PreviewCard athleteId={String(athleteId)} /> }
+      <div style={{ fontFamily: 'system-ui, -apple-system, Segoe UI, Roboto, Arial, sans-serif' }}>
+        {!athleteId ? (
+          <div style={{ maxWidth: 960, margin: '40px auto', padding: '0 16px' }}>
+            <h1 style={{ fontSize: 22, fontWeight: 800, marginBottom: 8 }}>Missing athlete id</h1>
+            <p>Apri come <code>/profile/preview?id=&lt;athleteId&gt;</code>.</p>
+          </div>
+        ) : <PreviewCard athleteId={String(athleteId)} /> }
+      </div>
     </>
   );
 }


### PR DESCRIPTION
## Summary
- apply system font stack at top-level container of profile preview page for consistent typography

## Testing
- `npm test` *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68bd5fd96e4c832b9a6043056d267d7b