### PR TITLE
Fix intro video sizing

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -138,12 +138,10 @@ const styles = {
   mediaPreview: {
     width: '100%',
     maxWidth: 420,
-    aspectRatio: '16 / 9',
+    height: 'auto',
     background: '#000',
     border: '1px solid #EEE',
     borderRadius: 10,
-    objectFit: 'cover',
-    overflow: 'hidden',
     display: 'block',
     margin: '0 auto'
   },


### PR DESCRIPTION
## Summary
- ensure intro video scales proportionally to its original aspect ratio

## Testing
- `npm test` *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68c5bd56feb0832b8fc33f04e1332596