### PR TITLE
Ensure career inputs fill grid width

### DIFF
--- a/sections/sports/SportInfoPanel.jsx
+++ b/sections/sports/SportInfoPanel.jsx
@@ -1268,6 +1268,8 @@ const styles = {
     borderRadius: 10,
     fontSize: 14,
     background: '#FFF',
+    width: '100%',
+    boxSizing: 'border-box',
   },
   careerInput: {
     height: 38,
@@ -1276,6 +1278,8 @@ const styles = {
     borderRadius: 10,
     fontSize: 14,
     background: '#FFF',
+    width: '100%',
+    boxSizing: 'border-box',
   },
   error: { fontSize: 12, color: '#b00' },
 


### PR DESCRIPTION
## Summary
- ensure career widget inputs stretch to fill their grid columns
- apply border-box sizing so padding preserves layout alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68cedafcd730832b97a4188db2b939f9