### PR TITLE
Align highlight replace CTA styling on mobile

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -221,6 +221,11 @@ const styles = {
   statusTextERR:{ marginLeft: 10, fontWeight: 600, whiteSpace: 'nowrap', display: 'inline-flex', alignItems: 'center', color: '#b00' },
 };
 
+const primaryCtaStyles = {
+  enabled: { ...styles.saveBtn, ...styles.saveBtnEnabled },
+  disabled: { ...styles.saveBtn, ...styles.saveBtnDisabled },
+};
+
 // ------------------------------ UTILS ------------------------------
 const nowTs = () => Date.now();
 const bytesToMB = (b) => Math.round((Number(b || 0) / (1024 * 1024)) * 10) / 10;
@@ -1232,8 +1237,8 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
   if (loading) return <div style={{ padding: 8, color: '#666' }}>Loading…</div>;
 
   const saveBtnStyle = isSaveDisabled
-    ? { ...styles.saveBtn, ...styles.saveBtnDisabled }
-    : { ...styles.saveBtn, ...styles.saveBtnEnabled };
+    ? primaryCtaStyles.disabled
+    : primaryCtaStyles.enabled;
 
   // Pulsanti Add disabilitati a cap
   const addGalDisabled = gallery.length >= CAP.GALLERY;
@@ -1405,7 +1410,9 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
                       <button
                         type="button"
                         onClick={() => { if (!hlReplacingId) { hlReplaceRefs.current[it.id]?.click(); } }}
-                        style={hlReplacingId ? styles.smallBtnDisabled : styles.smallBtnPrimary}
+                        style={isMobile
+                          ? (hlReplacingId ? primaryCtaStyles.disabled : primaryCtaStyles.enabled)
+                          : (hlReplacingId ? styles.smallBtnDisabled : styles.smallBtnPrimary)}
                         disabled={Boolean(hlReplacingId)}
                       >
                         Replace


### PR DESCRIPTION
## Summary
- create a reusable primary CTA style based on the save button tokens
- apply the primary CTA styling to the mobile highlight Replace action while keeping desktop styling intact

## Testing
- npm run test *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68cfc3b4c5f8832b9c222946e82db08f