### PR TITLE
Sanitize GDPR policy HTML before rendering

### DIFF
--- a/sections/privacy/PrivacyPanel.jsx
+++ b/sections/privacy/PrivacyPanel.jsx
@@ -49,7 +49,23 @@ export default function PrivacyPanel({ athlete }) {
       })
       .then((html) => {
         if (!active) return;
-        setPolicyHtml(html);
+        let sanitizedHtml = html;
+
+        try {
+          const parser = new DOMParser();
+          const doc = parser.parseFromString(html, 'text/html');
+          if (doc) {
+            const root = doc.querySelector('main') || doc.body;
+            if (root) {
+              root.querySelectorAll('style').forEach((el) => el.remove());
+              sanitizedHtml = root.innerHTML;
+            }
+          }
+        } catch (parseError) {
+          console.warn('Failed to sanitize GDPR policy HTML', parseError);
+        }
+
+        setPolicyHtml(sanitizedHtml);
         setPolicyStatus('ready');
       })
       .catch((err) => {


### PR DESCRIPTION
## Summary
- parse the downloaded GDPR policy HTML before rendering in the dashboard
- strip style tags and render only the main content to avoid leaking global CSS rules

## Testing
- npm test *(fails: Missing script: "lint")*


------
https://chatgpt.com/codex/tasks/task_b_68d0249c79b4832b80e5cbf2213c383a