### PR TITLE
Implement dashboard completion recalculation

### DIFF
--- a/sections/awards/AwardsWidget.jsx
+++ b/sections/awards/AwardsWidget.jsx
@@ -24,7 +24,7 @@ const getFileNameFromPath = (p) => {
   return ix >= 0 ? s.slice(ix + 1) : s;
 };
 
-export default function AwardsWidget({ athleteId, isMobile }) {
+export default function AwardsWidget({ athleteId, isMobile, onSaved }) {
   const [rows, setRows] = useState([]);
   const [cLoading, setCLoading] = useState(true);
   const [cStatus, setCStatus] = useState({ type: '', msg: '' });
@@ -211,6 +211,7 @@ export default function AwardsWidget({ athleteId, isMobile }) {
       setAddEvidenceName('');
       setCStatus({ type: 'success', msg: 'Saved ✓' });
       await loadRows();
+      onSaved?.();
     } catch (e) {
       console.error(e);
       setCStatus({ type: 'error', msg: 'Save failed' });
@@ -274,6 +275,7 @@ export default function AwardsWidget({ athleteId, isMobile }) {
       setEditEvidenceName('');
       setCStatus({ type: 'success', msg: 'Saved ✓' });
       await loadRows();
+      onSaved?.();
     } catch (e) {
       console.error(e);
       setCStatus({ type: 'error', msg: 'Save failed' });
@@ -292,6 +294,7 @@ export default function AwardsWidget({ athleteId, isMobile }) {
       if (error) throw error;
       setCStatus({ type: 'success', msg: 'Deleted ✓' });
       await loadRows();
+      onSaved?.();
     } catch (e) {
       console.error(e);
       setCStatus({ type: 'error', msg: 'Delete failed' });

--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -9,7 +9,7 @@
 // - react-select/creatable (per i tag)
 // Non usa librerie DnD esterne: drag&drop HTML5 semplice per Gallery/Highlights.
 
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import CreatableSelect from 'react-select/creatable';
 import { supabase as sb } from '../../utils/supabaseClient';
 
@@ -401,6 +401,10 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
   const [status, setStatus]   = useState({ type: '', msg: '' });
   const [dirty, setDirty]     = useState(false);
 
+  const notifyParent = useCallback((fresh = null) => {
+    if (onSaved) onSaved(fresh);
+  }, [onSaved]);
+
   // Data snapshot (per confronto)
   const [snapshot, setSnapshot] = useState({
     featured: { head: null, g1: null, g2: null }, // media_item
@@ -611,6 +615,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
         setFeatured((p) => ({ ...p, [slotKey]: data }));
       }
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e4) {
       console.error(e4);
       setStatus({ type: 'error', msg: 'Upload failed' });
@@ -630,6 +635,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       await supabase.from(TBL_MEDIA).delete().eq('id', prev.id);
       setFeatured((p) => ({ ...p, [slotKey]: null }));
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Delete failed' });
@@ -706,6 +712,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       }
 
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e4) {
       console.error(e4);
       setStatus({ type: 'error', msg: 'Upload failed' });
@@ -724,6 +731,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       await supabase.from(TBL_MEDIA).delete().eq('id', intro.id);
       setIntro(null);
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Delete failed' });
@@ -780,6 +788,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       const list = [...highlights, data].sort(sortByOrder);
       setHighlights(list);
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e4) {
       console.error(e4);
       setStatus({ type: 'error', msg: 'Upload failed' });
@@ -826,6 +835,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       setHighlights((p) => [...p, data].sort(sortByOrder));
       setAddLinkHL({ url: '', err: '' });
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setAddLinkHL((p) => ({ ...p, err: 'Add failed' }));
@@ -842,6 +852,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       setHighlights((p) => p.filter(i => i.id !== id).map((i, idx) => ({ ...i, sort_order: idx })));
       setDirty(true); // riordino implicito
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e); setStatus({ type: 'error', msg: 'Delete failed' });
     }
@@ -889,6 +900,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
 
       setHighlights((p) => p.map(x => x.id === item.id ? data : x).sort(sortByOrder));
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Replace failed' });
@@ -967,6 +979,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
         setGallery((g) => [...g, data].sort(sortByOrder));
       }
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e3) {
       console.error(e3);
       setStatus({ type: 'error', msg: 'Upload failed' });
@@ -1011,6 +1024,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       const highlightsDirty = JSON.stringify(highlights) !== JSON.stringify(snapshot.highlights);
       setDirty(galleryDirty || highlightsDirty);
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Save failed' });
@@ -1026,6 +1040,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       setGallery((p) => p.filter(i => i.id !== id).map((i, idx) => ({ ...i, sort_order: idx })));
       setDirty(true);
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Delete failed' });
@@ -1121,6 +1136,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       }}, ...p].sort(sortGamesDesc));
       setAddGame({ url: '', match_date: '', opponent: '', competition: '', season: '', team_level: '', err: '' });
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setAddGame((p) => ({ ...p, err: 'Add failed' }));
@@ -1157,6 +1173,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       // ordine automatico per data: ri-ordina la lista
       setGames((p) => [...p].sort(sortGamesDesc));
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Save failed' });
@@ -1171,6 +1188,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       await supabase.from(TBL_MEDIA).delete().eq('id', media_item_id);
       setGames((p) => p.filter(g => g.item.id !== media_item_id));
       setStatus({ type: 'success', msg: 'Saved ✓' });
+      notifyParent();
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Delete failed' });
@@ -1221,10 +1239,8 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       setStatus({ type: 'success', msg: 'Saved ✓' });
 
       // callback parent (coerente con altre card)
-      if (onSaved) {
-        const { data: fresh } = await supabase.from('athlete').select('*').eq('id', athlete.id).single();
-        onSaved(fresh || null);
-      }
+      const { data: fresh } = await supabase.from('athlete').select('*').eq('id', athlete.id).single();
+      notifyParent(fresh || null);
     } catch (e) {
       console.error(e);
       setStatus({ type: 'error', msg: 'Save failed' });

--- a/utils/profileCompletion.js
+++ b/utils/profileCompletion.js
@@ -1,0 +1,212 @@
+const BASE_COMPLETION = 40;
+const SECTION_WEIGHT = 10;
+
+const MEDIA_CATEGORIES = {
+  FEATURED_HEAD: 'featured_headshot',
+  FEATURED_G1: 'featured_game1',
+  FEATURED_G2: 'featured_game2',
+  GALLERY: 'gallery',
+  INTRO: 'intro',
+  HIGHLIGHT: 'highlight',
+  GAME: 'game',
+};
+
+const REQUIRED_GAME_META_KEYS = ['match_date', 'opponent', 'competition', 'season', 'team_level'];
+
+function isFilled(value) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === 'string') return value.trim().length > 0;
+  if (typeof value === 'boolean') return value === true;
+  if (typeof value === 'number') return !Number.isNaN(value);
+  if (Array.isArray(value)) return value.length > 0;
+  if (value instanceof Date) return true;
+  if (typeof value === 'object') return Object.keys(value).length > 0;
+  return false;
+}
+
+function countFilled(values) {
+  const total = values.length;
+  if (total === 0) return { filled: 0, total: 0, ratio: 0 };
+  let filled = 0;
+  for (const v of values) {
+    if (isFilled(v)) filled += 1;
+  }
+  return { filled, total, ratio: filled / total };
+}
+
+function evaluateContacts(athlete, contactsVerification) {
+  const cv = contactsVerification || {};
+  const fields = [
+    athlete?.phone,
+    cv.id_document_type,
+    cv.id_document_url,
+    cv.id_selfie_url,
+    cv.residence_region || cv.state_region,
+    cv.residence_postal_code || cv.postal_code,
+    cv.residence_address || cv.address,
+    cv.residence_city,
+    cv.residence_country,
+  ];
+  if ((cv.id_document_type || '').toLowerCase() === 'other') {
+    fields.push(cv.id_document_type_other);
+  }
+  const stats = countFilled(fields);
+  const reviewStatus = (cv.review_status || '').toLowerCase();
+  const contributes = stats.total > 0 && stats.ratio === 1 && reviewStatus === 'approved';
+  return { ...stats, contributes, reviewStatus };
+}
+
+function evaluateSports(experience) {
+  if (!experience) return { filled: 0, total: 0, ratio: 0, contributes: false };
+  const groups = [
+    experience.sport,
+    experience.role,
+    experience.category,
+    experience.team,
+    experience.previous_team,
+    experience.years_experience,
+    experience.seeking_team === true || experience.seeking_team === false ? true : null,
+    experience.secondary_role,
+    experience.playing_style,
+    (experience.contract_status || experience.contract_end_date || experience.contract_notes) ? true : null,
+    Array.isArray(experience.preferred_regions) && experience.preferred_regions.length ? experience.preferred_regions : null,
+    experience.trial_window,
+    (experience.is_represented || experience.agent_name || experience.agency_name) ? true : null,
+  ];
+  const stats = countFilled(groups);
+  return { ...stats, contributes: stats.ratio >= 0.6 };
+}
+
+function evaluatePhysical(physicalRow) {
+  if (!physicalRow) return { filled: 0, total: 0, ratio: 0, contributes: false };
+  const groups = [
+    physicalRow.physical_measured_at,
+    physicalRow.height_cm,
+    physicalRow.weight_kg,
+    physicalRow.wingspan_cm,
+    physicalRow.standing_reach_cm,
+    physicalRow.body_fat_percent,
+    physicalRow.dominant_hand,
+    physicalRow.dominant_foot,
+    physicalRow.dominant_eye,
+    physicalRow.physical_notes,
+    physicalRow.performance_measured_at,
+    (physicalRow.grip_strength_left_kg || physicalRow.grip_strength_right_kg) ? true : null,
+    physicalRow.vertical_jump_cmj_cm,
+    physicalRow.standing_long_jump_cm,
+    (physicalRow.sprint_10m_s || physicalRow.sprint_20m_s || physicalRow.pro_agility_5_10_5_s) ? true : null,
+    physicalRow.sit_and_reach_cm,
+    physicalRow.plank_hold_s,
+    physicalRow.cooper_12min_m,
+    physicalRow.performance_notes,
+  ];
+  const stats = countFilled(groups);
+  return { ...stats, contributes: stats.ratio >= 0.6 };
+}
+
+function evaluateAwards(awards) {
+  const rows = Array.isArray(awards) ? awards : [];
+  let filled = 0;
+  let total = 0;
+  for (const row of rows) {
+    const parts = [
+      row.title,
+      row.awarding_entity,
+      row.date_awarded || row.season_start || row.season_end,
+      row.description,
+      row.evidence_file_path || row.evidence_external_url,
+    ];
+    const stats = countFilled(parts);
+    filled += stats.filled;
+    total += stats.total;
+  }
+  const ratio = total ? filled / total : 0;
+  return { filled, total, ratio, contributes: ratio >= 0.6 };
+}
+
+function evaluateMedia(mediaItems, mediaGameMeta) {
+  const items = Array.isArray(mediaItems) ? mediaItems : [];
+  const metaMap = new Map();
+  if (Array.isArray(mediaGameMeta)) {
+    for (const row of mediaGameMeta) {
+      if (row && row.media_item_id != null) metaMap.set(row.media_item_id, row);
+    }
+  }
+  const byCategory = (cat) => items.filter((it) => (it?.category || '') === cat);
+  const oneByCategory = (cat) => items.find((it) => (it?.category || '') === cat) || null;
+
+  const featuredHead = oneByCategory(MEDIA_CATEGORIES.FEATURED_HEAD);
+  const featuredG1 = oneByCategory(MEDIA_CATEGORIES.FEATURED_G1);
+  const featuredG2 = oneByCategory(MEDIA_CATEGORIES.FEATURED_G2);
+  const intro = oneByCategory(MEDIA_CATEGORIES.INTRO);
+
+  const gallery = byCategory(MEDIA_CATEGORIES.GALLERY);
+  const highlights = byCategory(MEDIA_CATEGORIES.HIGHLIGHT);
+  const gamesRaw = byCategory(MEDIA_CATEGORIES.GAME);
+  const games = gamesRaw.filter((item) => {
+    const meta = metaMap.get(item?.id) || {};
+    return REQUIRED_GAME_META_KEYS.every((key) => isFilled(meta[key]));
+  });
+
+  const slots = [
+    featuredHead,
+    featuredG1,
+    featuredG2,
+    intro,
+    gallery.length >= 1,
+    gallery.length >= 2,
+    gallery.length >= 3,
+    highlights.length >= 1,
+    highlights.length >= 2,
+    games.length >= 1,
+    games.length >= 2,
+  ];
+  const stats = countFilled(slots);
+  return { ...stats, contributes: stats.ratio >= 0.6 };
+}
+
+function evaluateSocial(socialProfiles) {
+  const rows = Array.isArray(socialProfiles) ? socialProfiles : [];
+  let filled = 0;
+  let total = 0;
+  for (const row of rows) {
+    const stats = countFilled([
+      row?.platform,
+      row?.profile_url,
+      row?.handle,
+    ]);
+    filled += stats.filled;
+    total += stats.total;
+  }
+  const ratio = total ? filled / total : 0;
+  return { filled, total, ratio, contributes: ratio >= 0.6 };
+}
+
+export function computeProfileCompletion({
+  athlete,
+  contactsVerification,
+  sportsExperience,
+  physical,
+  awards,
+  mediaItems,
+  mediaGameMeta,
+  socialProfiles,
+} = {}) {
+  const breakdown = {
+    contacts: evaluateContacts(athlete, contactsVerification),
+    sports: evaluateSports(sportsExperience),
+    physical: evaluatePhysical(physical),
+    awards: evaluateAwards(awards),
+    media: evaluateMedia(mediaItems, mediaGameMeta),
+    social: evaluateSocial(socialProfiles),
+  };
+
+  let completion = BASE_COMPLETION;
+  for (const key of Object.keys(breakdown)) {
+    if (breakdown[key].contributes) completion += SECTION_WEIGHT;
+  }
+  if (completion > 100) completion = 100;
+  return { completion, breakdown };
+}
+
+export { MEDIA_CATEGORIES };


### PR DESCRIPTION
## Summary
- add a shared profile completion helper that evaluates each dashboard card using the new threshold rules
- update the dashboard to load supplemental card data, recompute completion after saves, and persist the athlete percentage with a 40% floor
- notify the dashboard from awards and media widgets whenever their data changes so completion stays in sync

## Testing
- npm run test *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68d06da0fa08832b89e9f5bf487aa394