### PR TITLE
Update forgot password redirect to new site URL

### DIFF
--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -22,8 +22,9 @@ export default function ForgotPassword() {
     e.preventDefault();
     setError('');
     setMessage('');
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.talentlix.com';
     const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: 'https://talent-lix.vercel.app/reset-password',
+      redirectTo: `${siteUrl}/reset-password`,
     });
     if (error) setError(error.message);
     else setMessage('If an account exists for this email, you will receive a password reset link.');


### PR DESCRIPTION
## Summary
- update the forgot password flow to derive the redirect URL from `NEXT_PUBLIC_SITE_URL`
- default the reset URL to the production domain when the environment variable is absent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68d8231beb14832bb870ebc7ace39b44