### PR TITLE
Add guards for Supabase client initialization

### DIFF
--- a/utils/supabaseClient.js
+++ b/utils/supabaseClient.js
@@ -1,6 +1,22 @@
 import { createClient } from '@supabase/supabase-js';
 
-const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
-const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL ?? '';
+const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY ?? '';
 
-export const supabase = createClient(supabaseUrl, supabaseAnonKey);
+const hasSupabaseConfig =
+  typeof supabaseUrl === 'string' &&
+  supabaseUrl.trim() !== '' &&
+  typeof supabaseAnonKey === 'string' &&
+  supabaseAnonKey.trim() !== '';
+
+if (!hasSupabaseConfig) {
+  console.error(
+    'Supabase client not initialized: NEXT_PUBLIC_SUPABASE_URL and NEXT_PUBLIC_SUPABASE_ANON_KEY must be set in .env.local.'
+  );
+}
+
+export const supabase = hasSupabaseConfig
+  ? createClient(supabaseUrl, supabaseAnonKey)
+  : null;
+
+export const isSupabaseConfigured = hasSupabaseConfig;


### PR DESCRIPTION
## Summary
- verify Supabase environment variables before creating the client
- log a descriptive error and expose configuration status when variables are missing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d8f1b4d65c832ba44af17c377c6a2b