### PR TITLE
Ensure preview loader centers vertically

### DIFF
--- a/pages/profile/preview.js
+++ b/pages/profile/preview.js
@@ -229,7 +229,7 @@ function PreviewCard({ athleteId }) {
     colA:{ display:'flex', flexDirection:'column', gap:24 },
     colB:{ display:'flex', flexDirection:'column', gap:24 },
 
-    loaderContainer:{ display:'flex', alignItems:'center', justifyContent:'center', flexDirection:'column', gap:16, padding:48, textAlign:'center' },
+    loaderContainer:{ display:'flex', alignItems:'center', justifyContent:'center', flexDirection:'column', gap:16, padding:48, textAlign:'center', minHeight:'60vh' },
     spinner:{ width:48, height:48, borderRadius:'50%', border:'4px solid #27E3DA', borderTopColor:'#F7B84E', animation:'profilePreviewSpin 1s linear infinite' },
     srOnly:{ position:'absolute', width:1, height:1, padding:0, margin:-1, overflow:'hidden', clip:'rect(0,0,0,0)', whiteSpace:'nowrap', border:0 },
 


### PR DESCRIPTION
## Summary
- add a viewport-based minimum height to the preview loader container so the flexbox centering has vertical room to operate

## Testing
- next dev

------
https://chatgpt.com/codex/tasks/task_b_68d9353f441c832b8029e70b9d394eb1