### PR TITLE
Align wizard loading indicator with profile preview

### DIFF
--- a/pages/wizard.js
+++ b/pages/wizard.js
@@ -422,7 +422,16 @@ const handleLogout = async () => {
                 </div>
               )}
             </div>
-            <p style={styles.loading}>Loading Wizard...</p>
+            <div style={styles.loaderContainer} role="status" aria-live="polite">
+              <div style={styles.spinner} aria-hidden="true" />
+              <span style={styles.srOnly}>Loading profile…</span>
+            </div>
+            <style jsx>{`
+              @keyframes profilePreviewSpin {
+                from { transform: rotate(0deg); }
+                to { transform: rotate(360deg); }
+              }
+            `}</style>
           </div>
         </div>
       </div>
@@ -1718,5 +1727,34 @@ dropdownButton: {
   buttonDisabled: { background: '#ccc', color: '#fff', border: 'none', padding: '0.8rem', borderRadius: '8px', width: '100%', cursor: 'not-allowed' },
   reviewList: { textAlign: 'left', marginBottom: '1.5rem', lineHeight: '1.6' },
   error: { color: 'red', fontSize: '0.9rem', marginBottom: '1rem' },
-  loading: { textAlign: 'center', fontSize: '1.2rem' },
+  loaderContainer: {
+    display: 'flex',
+    alignItems: 'center',
+    justifyContent: 'center',
+    flexDirection: 'column',
+    gap: 16,
+    padding: 48,
+    textAlign: 'center',
+    minHeight: 'calc(100vh - 32px)',
+    width: '100%'
+  },
+  spinner: {
+    width: 48,
+    height: 48,
+    borderRadius: '50%',
+    border: '4px solid #27E3DA',
+    borderTopColor: '#F7B84E',
+    animation: 'profilePreviewSpin 1s linear infinite'
+  },
+  srOnly: {
+    position: 'absolute',
+    width: 1,
+    height: 1,
+    padding: 0,
+    margin: -1,
+    overflow: 'hidden',
+    clip: 'rect(0,0,0,0)',
+    whiteSpace: 'nowrap',
+    border: 0
+  },
 };


### PR DESCRIPTION
## Summary
- replace the wizard loading placeholder with the spinner pattern used by the profile preview page
- add shared loader, spinner, and sr-only styles so the animation and colors match the preview implementation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d93b477044832bbaf7c287d2caf6fe