### PR TITLE
Adjust highlight upload limit to five minutes

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -42,7 +42,7 @@ const CAT = {
 const LIM = {
   PHOTO_MAX_MB: 25,
   INTRO_MAX_SEC: 240,
-  HL_MAX_SEC: 360,    // 6 min
+  HL_MAX_SEC: 300,    // 5 min
   MAX_DIM_PX: 4096,   // check "≤4K": dimensione massima lato lungo
 };
 
@@ -608,7 +608,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       return `Duration ${duration}s exceeds the 4-minute upload limit (${LIM.INTRO_MAX_SEC}s).`;
     }
     if (kind === 'highlight' && duration > LIM.HL_MAX_SEC) {
-      return `Duration ${duration}s exceeds the 6-minute upload limit (${LIM.HL_MAX_SEC}s). For longer videos, use "Add Link".`;
+      return `Duration ${duration}s exceeds the 5-minute upload limit (${LIM.HL_MAX_SEC}s). For longer videos, use "Add Link".`;
     }
     const maxSide = Math.max(Number(width || 0), Number(height || 0));
     if (maxSide && maxSide > LIM.MAX_DIM_PX) return `Resolution too high (${width}×${height}). Limit ≤ 4K.`;
@@ -1451,14 +1451,14 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       {/* HIGHLIGHTS */}
       <div style={styles.box}>
         <div style={styles.sectionTitle}>Highlights (max 3 — upload or link)</div>
-        <div style={styles.subnote}>Poster/thumbnail always present; drag & drop to sort; edit title/caption/tags; inline player. Uploads capped at 6 minutes — use "Add Link" for longer footage.
+        <div style={styles.subnote}>Poster/thumbnail always present; drag & drop to sort; edit title/caption/tags; inline player. Uploads capped at 5 minutes — use "Add Link" for longer footage.
           {addHLDisabled && <strong style={{ color: '#b00' }}> Limit reached: replace or remove.</strong>}
         </div>
 
         {/* Azioni add */}
         <div style={{ ...styles.fieldRow, flexDirection: 'column', alignItems: 'center', rowGap: 8 }}>
           <div style={{ fontSize: 12, color: '#666', textAlign: 'center', maxWidth: 460 }}>
-            Upload clips up to 6 minutes. Need longer footage? Use "+ Add Link" to embed YouTube or Vimeo videos.
+            Upload clips up to 5 minutes. Need longer footage? Use "+ Add Link" to embed YouTube or Vimeo videos.
           </div>
           <div>
             <input type="file" accept="video/mp4,video/quicktime,video/webm" ref={hlUploadInputRef} onChange={onPickHLUpload} style={{ display: 'none' }}/>


### PR DESCRIPTION
## Summary
- lower the highlight upload duration limit to five minutes in the media panel logic
- refresh the duration-related validation message and UI copy to match the new limit

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da2c33bd58832b9f159d04ac90f3af