### PR TITLE
Update intro video duration limit to 3 minutes

### DIFF
--- a/sections/media/MediaPanel.jsx
+++ b/sections/media/MediaPanel.jsx
@@ -41,7 +41,7 @@ const CAT = {
 // Limiti qualitativi definitivi
 const LIM = {
   PHOTO_MAX_MB: 25,
-  INTRO_MAX_SEC: 240,
+  INTRO_MAX_SEC: 180,
   HL_MAX_SEC: 300,    // 5 min
   MAX_DIM_PX: 4096,   // check "≤4K": dimensione massima lato lungo
 };
@@ -605,7 +605,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
   const checkVideoMeta = ({ duration, width, height }, kind) => {
     if (!duration || duration <= 0) return 'Corrupted video or missing metadata.';
     if (kind === 'intro' && duration > LIM.INTRO_MAX_SEC) {
-      return `Duration ${duration}s exceeds the 4-minute upload limit (${LIM.INTRO_MAX_SEC}s).`;
+      return `Duration ${duration}s exceeds the 3-minute (180s) upload limit (${LIM.INTRO_MAX_SEC}s).`;
     }
     if (kind === 'highlight' && duration > LIM.HL_MAX_SEC) {
       return `Duration ${duration}s exceeds the 5-minute upload limit (${LIM.HL_MAX_SEC}s). For longer videos, use "Add Link".`;
@@ -1410,7 +1410,7 @@ export default function MediaPanel({ athlete, onSaved, isMobile }) {
       {/* INTRO VIDEO */}
       <div style={styles.box}>
         <div style={styles.sectionTitle}>Video Intro (1)</div>
-        <div style={styles.subnote}>≤ 240s (4 min), ≤ 4K. MP4/MOV/WEBM. Inline player, poster generated.</div>
+        <div style={styles.subnote}>≤ 180s (3 min), ≤ 4K. MP4/MOV/WEBM. Inline player, poster generated.</div>
         <div style={styles.videoRow}>
           <div style={styles.introWrapper}>
             {intro ? (


### PR DESCRIPTION
## Summary
- lower the intro video duration limit to 180 seconds
- adjust validation messaging and UI copy to mention the new 3-minute cap

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68da2edd34e8832b9d5bbc3e23dc48f2