### PR TITLE
Enforce operator role metadata and guards

### DIFF
--- a/hooks/useOperatorGuard.js
+++ b/hooks/useOperatorGuard.js
@@ -1,0 +1,68 @@
+import { useEffect, useState } from 'react';
+import { useRouter } from 'next/router';
+import { supabase } from '../utils/supabaseClient';
+import {
+  buildOperatorUnauthorizedQuery,
+  isOperatorUser,
+  OPERATOR_LOGIN_PATH,
+} from '../utils/authRoles';
+
+export const useOperatorGuard = ({
+  redirectTo = OPERATOR_LOGIN_PATH,
+  includeReason = true,
+} = {}) => {
+  const router = useRouter();
+  const [state, setState] = useState({ loading: true, user: null, error: null });
+
+  useEffect(() => {
+    let active = true;
+
+    const verify = async () => {
+      if (!supabase) {
+        if (active) {
+          setState({ loading: false, user: null, error: new Error('Supabase not configured') });
+        }
+        return;
+      }
+
+      const { data, error } = await supabase.auth.getUser();
+      if (!active) return;
+
+      const user = data?.user || null;
+
+      if (error || !user) {
+        if (redirectTo) {
+          router.replace(redirectTo);
+        }
+        setState({ loading: false, user: null, error: error || null });
+        return;
+      }
+
+      if (!isOperatorUser(user)) {
+        await supabase.auth.signOut();
+        if (redirectTo) {
+          const query = includeReason ? buildOperatorUnauthorizedQuery() : undefined;
+          router.replace(
+            query ? { pathname: redirectTo, query } : redirectTo,
+            undefined,
+            { shallow: true }
+          );
+        }
+        if (active) {
+          setState({ loading: true, user: null, error: null });
+        }
+        return;
+      }
+
+      setState({ loading: false, user, error: null });
+    };
+
+    verify();
+
+    return () => {
+      active = false;
+    };
+  }, [includeReason, redirectTo, router]);
+
+  return state;
+};

--- a/pages/operator-wizard.js
+++ b/pages/operator-wizard.js
@@ -1,36 +1,13 @@
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { useRouter } from 'next/router';
 import { supabase } from '../utils/supabaseClient';
+import { useOperatorGuard } from '../hooks/useOperatorGuard';
 
 export default function OperatorWizard() {
   const router = useRouter();
-  const [checking, setChecking] = useState(true);
-  const [userEmail, setUserEmail] = useState('');
   const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    let isMounted = true;
-
-    const verifySession = async () => {
-      const { data: { user } } = await supabase.auth.getUser();
-
-      if (!user) {
-        router.replace('/login-operator');
-        return;
-      }
-
-      if (isMounted) {
-        setUserEmail(user?.email || '');
-        setChecking(false);
-      }
-    };
-
-    verifySession();
-
-    return () => {
-      isMounted = false;
-    };
-  }, [router]);
+  const { loading: checking, user } = useOperatorGuard();
+  const userEmail = user?.email || '';
 
   const toggleMenu = () => setMenuOpen((open) => !open);
 

--- a/pages/register-operator.js
+++ b/pages/register-operator.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
+import { OPERATOR_ROLE } from '../utils/authRoles';
 import { useRouter } from 'next/router';
 
 export default function RegisterOperator() {
@@ -34,7 +35,11 @@ export default function RegisterOperator() {
       return;
     }
 
-    const { data, error: signUpError } = await supabase.auth.signUp({ email, password });
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { role: OPERATOR_ROLE } },
+    });
 
     if (signUpError) {
       setError(signUpError.message || 'An unexpected error occurred. Please try again.');

--- a/pages/register.js
+++ b/pages/register.js
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
+import { ATHLETE_ROLE } from '../utils/authRoles';
 import { useRouter } from 'next/router';
 
 export default function Register() {
@@ -34,7 +35,11 @@ export default function Register() {
       return;
     }
 
-    const { data, error: signUpError } = await supabase.auth.signUp({ email, password });
+    const { data, error: signUpError } = await supabase.auth.signUp({
+      email,
+      password,
+      options: { data: { role: ATHLETE_ROLE } },
+    });
 
     if (signUpError) {
       setError(signUpError.message || 'An unexpected error occurred. Please try again.');

--- a/utils/authRoles.js
+++ b/utils/authRoles.js
@@ -1,0 +1,33 @@
+export const ATHLETE_ROLE = 'athlete';
+export const OPERATOR_ROLE = 'operator';
+export const OPERATOR_LOGIN_PATH = '/login-operator';
+export const OPERATOR_GUARD_REDIRECT_QUERY_KEY = 'reason';
+export const OPERATOR_GUARD_UNAUTHORIZED_VALUE = 'not_operator';
+export const OPERATOR_UNAUTHORIZED_MESSAGE = 'Account non abilitato come operatore.';
+
+const normalizeRole = (role) => (typeof role === 'string' ? role.toLowerCase() : null);
+
+export const hasRole = (user, role) => {
+  if (!user || !role) return false;
+
+  const normalizedRole = normalizeRole(role);
+  if (!normalizedRole) return false;
+
+  const metadataRole = normalizeRole(user?.user_metadata?.role);
+  if (metadataRole) {
+    return metadataRole === normalizedRole;
+  }
+
+  const appRoles = user?.app_metadata?.roles;
+  if (Array.isArray(appRoles)) {
+    return appRoles.some((value) => normalizeRole(value) === normalizedRole);
+  }
+
+  return false;
+};
+
+export const isOperatorUser = (user) => hasRole(user, OPERATOR_ROLE);
+
+export const buildOperatorUnauthorizedQuery = () => ({
+  [OPERATOR_GUARD_REDIRECT_QUERY_KEY]: OPERATOR_GUARD_UNAUTHORIZED_VALUE,
+});


### PR DESCRIPTION
## Summary
- add shared role constants and a reusable operator authorization hook
- mark new Supabase signups with athlete or operator roles in metadata
- enforce operator role checks on login and operator-only views with clearer feedback

## Testing
- npm test *(fails: Missing script: "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68e18b6a5394832bba4cf7e9e657788e