### PR TITLE
Verify operator before password reset

### DIFF
--- a/utils/operatorHelpers.js
+++ b/utils/operatorHelpers.js
@@ -1,0 +1,66 @@
+import { OPERATOR_ROLE } from './authRoles';
+
+const normalizeEmail = (email) => (typeof email === 'string' ? email.trim().toLowerCase() : '');
+
+const extractRoleFromRecord = (record) => {
+  if (!record || typeof record !== 'object') return null;
+
+  const directRole = record.role || record.user_role || record.account_role;
+  if (typeof directRole === 'string') return directRole.toLowerCase();
+
+  const metadataRole = record?.metadata?.role || record?.user_metadata?.role || record?.app_metadata?.role;
+  if (typeof metadataRole === 'string') return metadataRole.toLowerCase();
+
+  return null;
+};
+
+const candidateTables = ['operator_profiles', 'profiles', 'operators'];
+
+const queryOperatorTable = async (supabaseClient, table, email) =>
+  supabaseClient
+    .from(table)
+    .select('id, email, role, user_role, account_role, metadata, user_metadata, app_metadata')
+    .ilike('email', email)
+    .maybeSingle();
+
+export const fetchOperatorByEmail = async (supabaseClient, rawEmail) => {
+  const email = normalizeEmail(rawEmail);
+
+  if (!email) {
+    return { data: null, error: new Error('Email mancante.') };
+  }
+
+  if (!supabaseClient) {
+    return { data: null, error: new Error('Supabase client non configurato.') };
+  }
+
+  for (const table of candidateTables) {
+    try {
+      const { data, error } = await queryOperatorTable(supabaseClient, table, email);
+
+      if (error) {
+        if (error.code === '42P01') {
+          // Table does not exist; try next candidate.
+          continue;
+        }
+
+        if (error.code === 'PGRST116') {
+          // No rows returned for this table; try next candidate.
+          continue;
+        }
+
+        return { data: null, error };
+      }
+
+      if (data) {
+        return { data, error: null };
+      }
+    } catch (err) {
+      return { data: null, error: err };
+    }
+  }
+
+  return { data: null, error: null };
+};
+
+export const isOperatorRecord = (record) => extractRoleFromRecord(record) === OPERATOR_ROLE;


### PR DESCRIPTION
## Summary
- ensure the operator password reset form verifies the submitted email belongs to an operator before requesting a reset
- surface the existing operator unauthorized message when the email fails the role guard
- add a reusable helper that looks up operator accounts by email for future operator-only flows

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e18ef0d070832bb32b116d73992d1e