### PR TITLE
Align password reset success messaging

### DIFF
--- a/pages/forgot-password-operator.js
+++ b/pages/forgot-password-operator.js
@@ -4,6 +4,7 @@ import Link from 'next/link';
 import { useRouter } from 'next/router';
 import { OPERATOR_UNAUTHORIZED_MESSAGE } from '../utils/authRoles';
 import { fetchOperatorByEmail, isOperatorRecord } from '../utils/operatorHelpers';
+import { PASSWORD_RESET_EMAIL_MESSAGE } from '../utils/resetPasswordMessages';
 
 export default function ForgotPasswordOperator() {
   const [email, setEmail] = useState('');
@@ -42,7 +43,7 @@ export default function ForgotPasswordOperator() {
       redirectTo: `${siteUrl}/reset-password-operator`,
     });
     if (error) setError(error.message);
-    else setMessage('If an operator account exists for this email, you will receive a password reset link.');
+    else setMessage(PASSWORD_RESET_EMAIL_MESSAGE);
   };
 
   return (

--- a/pages/forgot-password.js
+++ b/pages/forgot-password.js
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
+import { PASSWORD_RESET_EMAIL_MESSAGE } from '../utils/resetPasswordMessages';
 
 export default function ForgotPassword() {
   const [email, setEmail] = useState('');
@@ -27,7 +28,7 @@ export default function ForgotPassword() {
       redirectTo: `${siteUrl}/reset-password`,
     });
     if (error) setError(error.message);
-    else setMessage('If an account exists for this email, you will receive a password reset link.');
+    else setMessage(PASSWORD_RESET_EMAIL_MESSAGE);
   };
 
   return (

--- a/utils/resetPasswordMessages.js
+++ b/utils/resetPasswordMessages.js
@@ -1,0 +1,1 @@
+export const PASSWORD_RESET_EMAIL_MESSAGE = 'If an account exists for this email, you will receive a password reset link.';


### PR DESCRIPTION
## Summary
- extract the shared password reset success message into a utility constant
- use the shared message in both athlete and operator forgot password flows to keep messaging consistent

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68e1917d5194832baba3864ff16e8f18