### PR TITLE
Add Back to Home link to login page

### DIFF
--- a/pages/login.js
+++ b/pages/login.js
@@ -63,6 +63,9 @@ export default function Login() {
             <p style={styles.footerText}>
               Don’t have an account? <a href="/register" style={styles.link}>Register</a>
             </p>
+            <p style={styles.footerText}>
+              <a href="/" style={styles.link}>Back to Home</a>
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a Back to Home link under the login card's footer prompts using the existing styles for consistency

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1930eef6c832b91b70d7dd131feff