### PR TITLE
Add homepage link to operator login footer

### DIFF
--- a/pages/login-operator.js
+++ b/pages/login-operator.js
@@ -99,6 +99,9 @@ export default function LoginOperator() {
             <p style={styles.footerText}>
               Don’t have an operator account? <a href="/register-operator" style={styles.link}>Register</a>
             </p>
+            <p style={styles.footerText}>
+              Want to return to the main site? <a href="/" style={styles.link}>Go back home</a>
+            </p>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- add a homepage link to the operator login footer using the existing footer and link styles for visual consistency

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68e193136f48832b8f6d454ce5adf3ce