### PR TITLE
Allow landing page access without redirect

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -1,11 +1,7 @@
 import Link from 'next/link';
 import { useEffect } from 'react';
-import { useRouter } from 'next/router';
-import { supabase } from '../utils/supabaseClient';
 
 export default function Home() {
-  const router = useRouter();
-
   useEffect(() => {
     (async () => {
       try {
@@ -26,15 +22,11 @@ export default function Home() {
         if (typeof window !== 'undefined' && window.location.hash) {
           window.history.replaceState(null, '', window.location.pathname);
         }
-
-        // Already logged in → dashboard
-        const { data: { user } } = await supabase.auth.getUser();
-        if (user) router.push('/dashboard');
       } catch (e) {
         // fail silently, do not affect UI
       }
     })();
-  }, [router]);
+  }, []);
 
   return (
     <div style={styles.page}>


### PR DESCRIPTION
## Summary
- remove the automatic redirect to /dashboard on the home page when a user session exists
- keep the confirmation link hash handling intact so success and error alerts still surface

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1940b0978832b9de1f34b4d529304