### PR TITLE
Adjust operator login footer link text

### DIFF
--- a/pages/login-operator.js
+++ b/pages/login-operator.js
@@ -100,7 +100,7 @@ export default function LoginOperator() {
               Don’t have an operator account? <a href="/register-operator" style={styles.link}>Register</a>
             </p>
             <p style={styles.footerText}>
-              Want to return to the main site? <a href="/" style={styles.link}>Go back home</a>
+              <a href="/" style={styles.link}>Back to Home</a>
             </p>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- update the operator login footer link to display the "Back to Home" wording

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e196615784832bafad930005c83c2e