### PR TITLE
Ensure operator reset flow uses neutral confirmation message

### DIFF
--- a/pages/forgot-password-operator.js
+++ b/pages/forgot-password-operator.js
@@ -2,7 +2,6 @@ import { useState, useEffect } from 'react';
 import { supabase } from '../utils/supabaseClient';
 import Link from 'next/link';
 import { useRouter } from 'next/router';
-import { OPERATOR_UNAUTHORIZED_MESSAGE } from '../utils/authRoles';
 import { fetchOperatorByEmail, isOperatorRecord } from '../utils/operatorHelpers';
 import { PASSWORD_RESET_EMAIL_MESSAGE } from '../utils/resetPasswordMessages';
 
@@ -34,7 +33,8 @@ export default function ForgotPasswordOperator() {
     }
 
     if (!isOperatorRecord(operatorRecord)) {
-      setError(OPERATOR_UNAUTHORIZED_MESSAGE);
+      setError('');
+      setMessage(PASSWORD_RESET_EMAIL_MESSAGE);
       return;
     }
 


### PR DESCRIPTION
## Summary
- show the same neutral password reset confirmation message for operator lookups that do not match an operator account
- remove the unused operator unauthorized message import from the forgot password page

## Testing
- not run (UI verification requires full environment)

------
https://chatgpt.com/codex/tasks/task_b_68e196b3043c832b876a9bf64fa2f47b