### PR TITLE
Update operator forgot password error messaging

### DIFF
--- a/pages/forgot-password-operator.js
+++ b/pages/forgot-password-operator.js
@@ -28,7 +28,7 @@ export default function ForgotPasswordOperator() {
 
     if (lookupError) {
       console.error('Unable to verify operator account for reset password flow.', lookupError);
-      setError('Impossibile verificare il ruolo operatore. Riprova.');
+      setError(lookupError.message || 'Unable to verify the operator account. Please try again.');
       return;
     }
 


### PR DESCRIPTION
## Summary
- surface Supabase lookup error messaging in the operator forgot password flow
- provide an English fallback when the operator lookup fails so messaging matches the user flow

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68e1989622a8832baa26a753ac6aeca4