### PR TITLE
Prevent operators from accessing athlete login

### DIFF
--- a/utils/authRoles.js
+++ b/utils/authRoles.js
@@ -27,6 +27,7 @@ export const hasRole = (user, role) => {
 };
 
 export const isOperatorUser = (user) => hasRole(user, OPERATOR_ROLE);
+export const isAthleteUser = (user) => hasRole(user, ATHLETE_ROLE);
 
 export const buildOperatorUnauthorizedQuery = () => ({
   [OPERATOR_GUARD_REDIRECT_QUERY_KEY]: OPERATOR_GUARD_UNAUTHORIZED_VALUE,


### PR DESCRIPTION
## Summary
- add an `isAthleteUser` helper to centralize athlete role checks
- block non-athlete accounts from being redirected to the athlete dashboard during automatic and manual login flows
- provide guidance for operators to use their dedicated login path when they attempt to sign in via the athlete portal

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e1a51fbfb0832bb63f150253ed1540