### PR TITLE
Translate authentication messaging to English

### DIFF
--- a/pages/login-operator.js
+++ b/pages/login-operator.js
@@ -66,7 +66,7 @@ export default function LoginOperator() {
 
       if (userError || !user) {
         await supabase.auth.signOut();
-        setError('Impossibile verificare il ruolo operatore. Riprova.');
+        setError('Unable to verify the operator role. Please try again.');
       } else if (!isOperatorUser(user)) {
         await supabase.auth.signOut();
         setError(OPERATOR_UNAUTHORIZED_MESSAGE);

--- a/pages/login.js
+++ b/pages/login.js
@@ -9,7 +9,7 @@ export default function Login() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
   const router = useRouter();
-  const nonAthleteMessage = `Account non abilitato come atleta.`;
+  const nonAthleteMessage = 'This account is not authorized for athlete access.';
 
   // 👇 Redirect automatico se già loggato
   useEffect(() => {

--- a/utils/authRoles.js
+++ b/utils/authRoles.js
@@ -3,7 +3,7 @@ export const OPERATOR_ROLE = 'operator';
 export const OPERATOR_LOGIN_PATH = '/login-operator';
 export const OPERATOR_GUARD_REDIRECT_QUERY_KEY = 'reason';
 export const OPERATOR_GUARD_UNAUTHORIZED_VALUE = 'not_operator';
-export const OPERATOR_UNAUTHORIZED_MESSAGE = 'Account non abilitato come operatore.';
+export const OPERATOR_UNAUTHORIZED_MESSAGE = 'This account is not authorized for operator access.';
 
 const normalizeRole = (role) => (typeof role === 'string' ? role.toLowerCase() : null);
 

--- a/utils/operatorHelpers.js
+++ b/utils/operatorHelpers.js
@@ -27,11 +27,11 @@ export const fetchOperatorByEmail = async (supabaseClient, rawEmail) => {
   const email = normalizeEmail(rawEmail);
 
   if (!email) {
-    return { data: null, error: new Error('Email mancante.') };
+    return { data: null, error: new Error('Email is missing.') };
   }
 
   if (!supabaseClient) {
-    return { data: null, error: new Error('Supabase client non configurato.') };
+    return { data: null, error: new Error('Supabase client is not configured.') };
   }
 
   for (const table of candidateTables) {


### PR DESCRIPTION
## Summary
- update athlete login guard messaging to use clear English text
- translate operator authorization warnings and fallback messaging
- convert operator helper error responses to English phrases for consistency

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68e20d8dba6c832b8ab51dc36438935f