### PR TITLE
Translate operator page text to English

### DIFF
--- a/pages/operator.js
+++ b/pages/operator.js
@@ -135,7 +135,7 @@ export default function Operator() {
   };
 
   const doReject = async (athleteId) => {
-    const reason = window.prompt('Motivo del rifiuto (opzionale):', '');
+    const reason = window.prompt('Rejection reason (optional):', '');
     try {
       setBusy(athleteId);
       const { error } = await supabase
@@ -165,7 +165,7 @@ export default function Operator() {
           {loading ? 'Loading…' : 'Refresh'}
         </button>
         <span style={{ fontSize: 12, color: '#666' }}>
-          Sola lettura + azioni su profili già “submitted”. Nessuna modifica allo schema.
+          Read-only view plus actions on profiles already “submitted.” No schema changes.
         </span>
       </div>
 
@@ -242,7 +242,7 @@ export default function Operator() {
         })}
 
         {ordered.length === 0 && !loading && (
-          <div style={{ padding: 20, color: '#666' }}>Nessun atleta trovato.</div>
+          <div style={{ padding: 20, color: '#666' }}>No athletes found.</div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- replace the rejection prompt with an English message
- translate the helper span and empty-state copy to English so the UI is consistent

## Testing
- not run (not needed)

------
https://chatgpt.com/codex/tasks/task_b_68e20d8ed000832bbe388cf8e84b7fc3