### PR TITLE
Update operator password reset lookup

### DIFF
--- a/pages/forgot-password-operator.js
+++ b/pages/forgot-password-operator.js
@@ -32,14 +32,20 @@ export default function ForgotPasswordOperator() {
       return;
     }
 
-    if (!isOperatorRecord(operatorRecord)) {
-      setError('');
-      setMessage(PASSWORD_RESET_EMAIL_MESSAGE);
+    if (!operatorRecord) {
+      setError('We couldn’t find an operator account with that email address.');
       return;
     }
 
+    if (!isOperatorRecord(operatorRecord)) {
+      setError('This operator account is not eligible for password resets. Please contact support.');
+      return;
+    }
+
+    const targetEmail = operatorRecord?.contact?.email_primary || email;
+
     const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.talentlix.com';
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
+    const { error } = await supabase.auth.resetPasswordForEmail(targetEmail, {
       redirectTo: `${siteUrl}/reset-password-operator`,
     });
     if (error) setError(error.message);


### PR DESCRIPTION
## Summary
- switch the operator reset lookup to query op_contact with the related op_account metadata
- add stricter validation for operator eligibility based on account status and operator type data
- update the forgot password flow to surface errors when no operator account is found and send resets to the matched email

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e223d8935c832ba0e71f68bae479af