### PR TITLE
Fix operator wizard to use account id for downstream tables

### DIFF
--- a/pages/operator-wizard.js
+++ b/pages/operator-wizard.js
@@ -135,7 +135,7 @@ export default function OperatorWizard() {
 
   const operatorAuthId = user?.id || null;
   const accountId = account?.id || null;
-  const opId = account?.op_id || null;
+  const opId = account?.id || null;
   const email = user?.email || '';
 
   const toggleMenu = () => setMenuOpen((open) => !open);
@@ -157,7 +157,6 @@ export default function OperatorWizard() {
           .from('op_account')
           .select(`
             id,
-            op_id,
             wizard_status,
             wizard_started_at,
             wizard_updated_at,


### PR DESCRIPTION
## Summary
- stop requesting the deprecated `op_id` column from `op_account`
- use the existing `id` column as the operator identifier when saving related records

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68e22cc68568832b9c2396ef9396706e