### PR TITLE
Align operator wizard background asset

### DIFF
--- a/pages/operator-wizard.js
+++ b/pages/operator-wizard.js
@@ -1250,7 +1250,11 @@ const twoCols = {
 
 const styles = {
   background: {
-    background: 'url(/operator-bg.jpg) center/cover no-repeat fixed',
+    backgroundImage: "url('/BackG.png')",
+    backgroundPosition: 'center',
+    backgroundSize: 'cover',
+    backgroundRepeat: 'no-repeat',
+    backgroundAttachment: 'fixed',
     minHeight: '100vh',
     display: 'flex',
     alignItems: 'center',


### PR DESCRIPTION
## Summary
- update the operator wizard background styling to reuse the shared BackG.png asset and keep the cover layout parameters

## Testing
- npm run dev

------
https://chatgpt.com/codex/tasks/task_b_68e2310122c0832baaefe82ab1b51d1f