### PR TITLE
Adjust panel layout spacing for responsive cards

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -164,7 +164,7 @@ export default function Home() {
 
         .panel {
           --panel-padding: 1.75rem;
-          --panel-min-height: 360px;
+          --panel-min-height: auto;
         }
 
         @media (max-width: 640px) {
@@ -277,7 +277,7 @@ const styles = {
     flexDirection: 'column',
     textAlign: 'center',
     alignItems: 'center',
-    justifyContent: 'space-between',
+    justifyContent: 'flex-start',
   },
   panelHeader: {
     marginBottom: '1.1rem',
@@ -311,7 +311,7 @@ const styles = {
   ctaRow: {
     display: 'flex',
     gap: '0.6rem',
-    marginTop: '1rem',
+    marginTop: '1.25rem',
     flexWrap: 'wrap',
     justifyContent: 'center',
   },


### PR DESCRIPTION
## Summary
- allow desktop panels to shrink with their content by removing the enforced min-height
- align panel content to the top so descriptions and CTAs flow naturally
- add breathing room above CTA buttons while confirming mobile styling remains intact

## Testing
- npm test *(fails: Missing script "lint")*
- npm run dev

------
https://chatgpt.com/codex/tasks/task_b_68e268165004832bb39d007454eeed34