### PR TITLE
Add operator verification management to internal enabler

### DIFF
--- a/pages/internal-enabler.js
+++ b/pages/internal-enabler.js
@@ -8,10 +8,20 @@ const cellHead = { padding: 10, borderRight: '1px solid #EEE' };
 const cell = { padding: 10, borderRight: '1px solid #EEE' };
 
 const badgeStyle = (status) => {
+  const value = String(status || '').toLowerCase();
   const base = { padding: '2px 8px', borderRadius: 999, fontSize: 12, fontWeight: 600 };
-  if (status === 'approved')  return { ...base, color: '#2E7D32', border: '1px solid #2E7D32' };
-  if (status === 'submitted') return { ...base, color: '#8A6D3B', border: '1px solid #8A6D3B' };
-  if (status === 'rejected')  return { ...base, color: '#B00020', border: '1px solid #B00020' };
+  if (value === 'approved' || value === 'verified' || value === 'completed') {
+    return { ...base, color: '#2E7D32', border: '1px solid #2E7D32' };
+  }
+  if (value === 'submitted' || value === 'in_review') {
+    return { ...base, color: '#8A6D3B', border: '1px solid #8A6D3B' };
+  }
+  if (value === 'needs_more_info') {
+    return { ...base, color: '#0277BD', border: '1px solid #0277BD' };
+  }
+  if (value === 'rejected') {
+    return { ...base, color: '#B00020', border: '1px solid #B00020' };
+  }
   return { ...base, color: '#555', border: '1px solid #AAA' }; // draft/unknown
 };
 
@@ -27,9 +37,9 @@ const actionBtn = (disabled, color) => ({
   cursor: disabled ? 'not-allowed' : 'pointer'
 });
 
-async function signedUrl(path) {
+async function signedUrl(path, bucket = 'documents') {
   if (!path) return '';
-  const { data, error } = await supabase.storage.from('documents').createSignedUrl(path, 60);
+  const { data, error } = await supabase.storage.from(bucket).createSignedUrl(path, 60);
   return error ? '' : (data?.signedUrl || '');
 }
 
@@ -37,8 +47,11 @@ export default function Operator() {
   const [rows, setRows] = useState([]);
   const [loading, setLoading] = useState(true);
   const [busy, setBusy] = useState(null); // athlete_id in lavorazione
+  const [opRows, setOpRows] = useState([]);
+  const [opLoading, setOpLoading] = useState(true);
+  const [opBusy, setOpBusy] = useState(null); // op_id in lavorazione
 
-  const load = async () => {
+  const loadAthletes = async () => {
     setLoading(true);
     // LEFT JOIN: athlete + eventuale riga in contacts_verification
     const { data, error } = await supabase
@@ -69,7 +82,68 @@ export default function Operator() {
     setLoading(false);
   };
 
-  useEffect(() => { load(); }, []);
+  const loadOperators = async () => {
+    setOpLoading(true);
+    try {
+      const { data, error } = await supabase
+        .from('op_account')
+        .select(`
+          id, status, wizard_status, type_id,
+          op_profile:op_profile(legal_name, trade_name, vat_number, tax_id, country, city, address1, address2),
+          op_contact:op_contact(email_primary, phone_e164, phone_verified_at),
+          op_verification_request:op_verification_request(
+            id, state, reason, submitted_at, created_at, updated_at,
+            op_verification_document:op_verification_document(doc_type, file_key)
+          )
+        `);
+      if (error) throw error;
+
+      const normalized = (data || []).map((row) => {
+        const profileArr = Array.isArray(row.op_profile) ? row.op_profile : (row.op_profile ? [row.op_profile] : []);
+        const contactArr = Array.isArray(row.op_contact) ? row.op_contact : (row.op_contact ? [row.op_contact] : []);
+        const reqArr = Array.isArray(row.op_verification_request)
+          ? row.op_verification_request
+          : (row.op_verification_request ? [row.op_verification_request] : []);
+
+        const profile = profileArr[0] || null;
+        const contact = contactArr[0] || null;
+
+        const sortedReqs = [...reqArr].sort((a, b) => {
+          const getTs = (r) => new Date(r?.submitted_at || r?.updated_at || r?.created_at || 0).getTime();
+          return getTs(b) - getTs(a);
+        });
+        const verificationRaw = sortedReqs[0] || null;
+        const docsRaw = verificationRaw?.op_verification_document;
+        const docs = Array.isArray(docsRaw) ? docsRaw : (docsRaw ? [docsRaw] : []);
+        const verification = verificationRaw ? { ...verificationRaw } : null;
+        if (verification) delete verification.op_verification_document;
+        const reviewState = String(verification?.state || row.wizard_status || '').toLowerCase() || 'not_started';
+
+        return {
+          id: row.id,
+          status: row.status || '',
+          wizard_status: row.wizard_status || '',
+          profile,
+          contact,
+          verification,
+          documents: docs,
+          review_state: reviewState,
+        };
+      });
+      setOpRows(normalized);
+    } catch (err) {
+      console.error(err);
+      setOpRows([]);
+    } finally {
+      setOpLoading(false);
+    }
+  };
+
+  const refreshAll = async () => {
+    await Promise.all([loadAthletes(), loadOperators()]);
+  };
+
+  useEffect(() => { refreshAll(); }, []);
 
   const ordered = useMemo(() => {
     // Focus immediato sui "submitted"
@@ -77,8 +151,25 @@ export default function Operator() {
     return [...rows].sort((a, b) => rank(a.review_status) - rank(b.review_status));
   }, [rows]);
 
+  const opOrdered = useMemo(() => {
+    const rank = (state) => {
+      const normalized = state || '';
+      if (normalized === 'submitted' || normalized === 'in_review') return 0;
+      if (normalized === 'needs_more_info') return 1;
+      if (normalized === 'rejected') return 2;
+      if (normalized === 'verified' || normalized === 'completed') return 3;
+      return 5;
+    };
+    return [...opRows].sort((a, b) => rank(a.review_state) - rank(b.review_state));
+  }, [opRows]);
+
   const viewDoc = async (key) => {
     const url = await signedUrl(key);
+    if (url) window.open(url, '_blank', 'noreferrer');
+  };
+
+  const viewOpDoc = async (key) => {
+    const url = await signedUrl(key, 'op_assets');
     if (url) window.open(url, '_blank', 'noreferrer');
   };
 
@@ -100,7 +191,7 @@ export default function Operator() {
         .eq('athlete_id', athleteId)
         .eq('review_status', 'submitted');
       if (error) throw error;
-      await load();
+      await refreshAll();
     } catch (e) {
       console.error(e); alert('Approve failed');
     } finally {
@@ -123,7 +214,7 @@ export default function Operator() {
         .eq('athlete_id', athleteId)
         .eq('review_status', 'submitted');
       if (error) throw error;
-      await load();
+      await refreshAll();
     } catch (e) {
       console.error(e); alert('Reject failed');
     } finally {
@@ -131,12 +222,58 @@ export default function Operator() {
     }
   };
 
+  const approveOperator = async (row) => {
+    if (!row?.verification?.id) { alert('Missing verification request.'); return; }
+    try {
+      setOpBusy(row.id);
+      const { error: reqErr } = await supabase
+        .from('op_verification_request')
+        .update({ state: 'VERIFIED', reason: null })
+        .eq('id', row.verification.id);
+      if (reqErr) throw reqErr;
+
+      const { error: accErr } = await supabase
+        .from('op_account')
+        .update({ status: 'active', wizard_status: 'COMPLETED' })
+        .eq('id', row.id);
+      if (accErr) throw accErr;
+
+      await refreshAll();
+    } catch (e) {
+      console.error(e); alert('Operator approve failed');
+    } finally {
+      setOpBusy(null);
+    }
+  };
+
+  const rejectOperator = async (row) => {
+    if (!row?.verification?.id) { alert('Missing verification request.'); return; }
+    const reason = window.prompt('Motivo del rifiuto (richiesto):', '');
+    if (reason === null) return;
+    const trimmed = reason.trim();
+    if (!trimmed) { alert('Inserire un motivo di rifiuto.'); return; }
+    try {
+      setOpBusy(row.id);
+      const { error: reqErr } = await supabase
+        .from('op_verification_request')
+        .update({ state: 'REJECTED', reason: trimmed })
+        .eq('id', row.verification.id);
+      if (reqErr) throw reqErr;
+
+      await refreshAll();
+    } catch (e) {
+      console.error(e); alert('Operator reject failed');
+    } finally {
+      setOpBusy(null);
+    }
+  };
+
   return (
     <div style={{ padding: 20, fontFamily: 'system-ui, Arial, sans-serif' }}>
       <h1 style={{ margin: '0 0 12px' }}>Operator – Identity Reviews (public)</h1>
       <div style={{ marginBottom: 12, display: 'flex', gap: 8, alignItems: 'center' }}>
-        <button onClick={load} disabled={loading} style={{ height: 36, padding: '0 12px', fontWeight: 600 }}>
-          {loading ? 'Loading…' : 'Refresh'}
+        <button onClick={refreshAll} disabled={loading || opLoading} style={{ height: 36, padding: '0 12px', fontWeight: 600 }}>
+          {loading || opLoading ? 'Loading…' : 'Refresh'}
         </button>
         <span style={{ fontSize: 12, color: '#666' }}>
           Sola lettura + azioni su profili già “submitted”. Nessuna modifica allo schema.
@@ -217,6 +354,93 @@ export default function Operator() {
 
         {ordered.length === 0 && !loading && (
           <div style={{ padding: 20, color: '#666' }}>Nessun atleta trovato.</div>
+        )}
+      </div>
+
+      <h2 style={{ margin: '32px 0 12px' }}>Operators – Verification</h2>
+      <div style={{ border: '1px solid #EEE', borderRadius: 12, overflow: 'hidden' }}>
+        <div style={{ display: 'grid', gridTemplateColumns: '260px 1fr 1fr 1fr 1fr', gap: 0, background: '#FAFAFA', fontWeight: 700 }}>
+          <div style={cellHead}>Operator</div>
+          <div style={cellHead}>Status</div>
+          <div style={cellHead}>Contacts</div>
+          <div style={cellHead}>Documents</div>
+          <div style={cellHead}>Actions</div>
+        </div>
+
+        {opOrdered.map((row) => {
+          const { profile, contact, verification, documents, review_state } = row;
+          const canAct = ['submitted', 'in_review', 'needs_more_info'].includes(review_state);
+          const reason = verification?.reason ? verification.reason : null;
+
+          return (
+            <div key={row.id} style={{ display: 'grid', gridTemplateColumns: '260px 1fr 1fr 1fr 1fr', borderTop: '1px solid #EEE' }}>
+              <div style={cell}>
+                <div style={{ fontWeight: 700 }}>{profile?.legal_name || profile?.trade_name || '—'}</div>
+                <div style={{ fontSize: 12, color: '#999' }}>
+                  {profile?.city || profile?.country ? [profile?.city, profile?.country].filter(Boolean).join(', ') : ''}
+                </div>
+                <div style={{ fontSize: 11, color: '#777', marginTop: 6 }}>
+                  Account: {row.status || '-'} · Wizard: {row.wizard_status || '-'}
+                </div>
+              </div>
+
+              <div style={cell}>
+                <span style={badgeStyle(review_state)}>{review_state}</span>
+                <div style={{ fontSize: 12, color: '#666', marginTop: 6 }}>
+                  Request: {verification ? (verification.state || '-') : '—'}
+                  {reason ? <div style={{ color: '#B00020' }}>Reason: {reason}</div> : null}
+                </div>
+              </div>
+
+              <div style={cell}>
+                <div style={{ fontSize: 13 }}>{contact?.email_primary || '-'}</div>
+                <div style={{ fontSize: 13 }}>{contact?.phone_e164 || '-'}</div>
+                <div style={{ fontSize: 12, color: contact?.phone_verified_at ? '#2E7D32' : '#B00020' }}>
+                  {contact?.phone_verified_at ? 'Phone verified ✓' : 'Phone not verified'}
+                </div>
+              </div>
+
+              <div style={cell}>
+                <div style={{ display: 'flex', gap: 8, marginTop: 4, flexWrap: 'wrap' }}>
+                  {documents.length === 0 && <span style={{ fontSize: 12, color: '#999' }}>—</span>}
+                  {documents.map((doc) => (
+                    <button
+                      key={`${doc.doc_type}-${doc.file_key}`}
+                      onClick={() => viewOpDoc(doc.file_key)}
+                      disabled={!doc.file_key}
+                      style={miniBtn(!doc.file_key)}
+                      title={doc.doc_type || 'Document'}
+                    >
+                      {doc.doc_type || 'Doc'}
+                    </button>
+                  ))}
+                </div>
+              </div>
+
+              <div style={cell}>
+                <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+                  <button
+                    onClick={() => approveOperator(row)}
+                    disabled={!canAct || opBusy === row.id}
+                    style={actionBtn(!canAct || opBusy === row.id, '#2E7D32')}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    onClick={() => rejectOperator(row)}
+                    disabled={!canAct || opBusy === row.id}
+                    style={actionBtn(!canAct || opBusy === row.id, '#B00020')}
+                  >
+                    Reject
+                  </button>
+                </div>
+              </div>
+            </div>
+          );
+        })}
+
+        {opOrdered.length === 0 && !opLoading && (
+          <div style={{ padding: 20, color: '#666' }}>Nessun operatore trovato.</div>
         )}
       </div>
     </div>


### PR DESCRIPTION
## Summary
- add operator-specific state, loading and data fetching alongside athlete handling
- surface operator verification details in a dedicated table with document access and actions
- implement approve/reject flows that update Supabase records and refresh both datasets

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68e2e6cc7128832b9b2d960d1d199595